### PR TITLE
Explicitly make redirects permanent

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,19 +3,23 @@
   "redirects": [
     {
       "source": "/connect/",
-      "destination": "/connect.html"
+      "destination": "/connect.html",
+      "permanent": true
     },
     {
       "source": "/grpchealth/",
-      "destination": "/grpchealth.html"
+      "destination": "/grpchealth.html",
+      "permanent": true
     },
     {
       "source": "/grpcreflect/",
-      "destination": "/grpcreflect.html"
+      "destination": "/grpcreflect.html",
+      "permanent": true
     },
     {
       "source": "/otelconnect/",
-      "destination": "/otelconnect.html"
+      "destination": "/otelconnect.html",
+      "permanent": true
     },
     {
       "source": "/docs/",


### PR DESCRIPTION
Redirects seem to be permanent by default, but this PR makes that explicit (and
matches the other rules).
