### PR TITLE
Update docs for new examples-es repo

### DIFF
--- a/docs/node/server-plugins.md
+++ b/docs/node/server-plugins.md
@@ -199,7 +199,7 @@ and response headers in the exposed headers. If your application uses trailers,
 they will be sent as header fields with a `Trailer-` prefix for Connect unary RPCs.
 
 For additional examples using CORS with the various flavors of Node.js servers,
-see the [Express](https://github.com/bufbuild/connect-es-integration/tree/main/express)
-and [Vanilla Node](https://github.com/bufbuild/connect-es-integration/tree/main/vanilla-node)
-examples in the [Connect ES Integration](https://github.com/bufbuild/connect-es-integration)
+see the [Express](https://github.com/connectrpc/examples-es/tree/main/express)
+and [Vanilla Node](https://github.com/connectrpc/examples-es/tree/main/vanilla-node)
+examples in the [examples-es](https://github.com/connectrpc/examples-es)
 repository.

--- a/docs/web/supported-browsers-and-frameworks.mdx
+++ b/docs/web/supported-browsers-and-frameworks.mdx
@@ -45,8 +45,8 @@ called [extensionAlias](https://webpack.js.org/configuration/resolve/#resolveext
 `resolve` section of your Webpack config file.  This will tell Webpack how to alias TypeScript file extensions and load
 them properly.
 
-For a working example, see the [Webpack project](https://github.com/bufbuild/connect-es-integration/tree/main/react/webpack)
-in the [Connect ES Integration](https://github.com/bufbuild/connect-es-integration) repo.
+For a working example, see the [Webpack project](https://github.com/connectrpc/examples-es/tree/main/react/webpack)
+in the [examples-es](https://github.com/connectrpc/examples-es) repo.
 
 ### v5.73.0 and below
 
@@ -109,8 +109,8 @@ the Webpack config in the above tools such as [react-app-rewired](https://github
 [Angular Builders Custom Webpack](https://www.npmjs.com/package/@angular-builders/custom-webpack)
 
 For a working example of the above with Create React App, see the
-[Create React App project](https://github.com/bufbuild/connect-es-integration/tree/main/react/cra) in the
-[Connect ES Integration](https://github.com/bufbuild/connect-es-integration) repo.
+[Create React App project](https://github.com/connectrpc/examples-es/tree/main/react/cra) in the
+[examples-es](https://github.com/connectrpc/examples-es) repo.
 
 ## Cypress
 
@@ -162,8 +162,8 @@ export default defineConfig({
 })
 ```
 
-For a working example, see the [Vue project](https://github.com/bufbuild/connect-es-integration/tree/main/vue)
-in the [Connect ES Integration](https://github.com/bufbuild/connect-es-integration) repo.
+For a working example, see the [Vue project](https://github.com/connectrpc/examples-es/tree/main/vue)
+in the [examples-es](https://github.com/connectrpc/examples-es) repo.
 
 ## Parcel
 
@@ -197,8 +197,8 @@ React Native due to some limitations in the above polyfills.
 If you would like to see improved support, please give us a +1 on [this issue](https://github.com/bufbuild/connect-es/issues/199)
 and we will prioritize it accordingly.
 
-For a working example, see the [React Native project](https://github.com/bufbuild/connect-es-integration/tree/main/react-native)
-in the [Connect ES Integration](https://github.com/bufbuild/connect-es-integration) repo.
+For a working example, see the [React Native project](https://github.com/connectrpc/examples-es/tree/main/react-native)
+in the [examples-es](https://github.com/connectrpc/examples-es) repo.
 
 ## Jest
 
@@ -225,5 +225,5 @@ as follows:
 }
 ```
 
-For a working example, see the [Create React App project](https://github.com/bufbuild/connect-es-integration/tree/main/react/cra)
-in the [Connect ES Integration](https://github.com/bufbuild/connect-es-integration) repo.
+For a working example, see the [Create React App project](https://github.com/connectrpc/examples-es/tree/main/react/cra)
+in the [examples-es](https://github.com/connectrpc/examples-es) repo.


### PR DESCRIPTION
This updates the docs to point to the new location for `examples-es` (FKA connect-es-integration)