### PR TITLE
Extend Connect for Web testing

### DIFF
--- a/docs/web/testing.mdx
+++ b/docs/web/testing.mdx
@@ -3,47 +3,165 @@ title: Testing
 sidebar_position: 20
 ---
 
-## Testing a client application
+Testing a client application can be a crucial part of ensuring its functionality
+and performance. When it comes to web applications, spinning up a full server
+to test against may not always be the best option. In the following sections, we
+will go through a couple of alternatives.
 
-Testing a client application can be a crucial part of ensuring its functionality and performance. When it comes to TypeScript projects, you can utilize the `createRouterTransport` method from `@connectrpc/connect` to create a mock transport that can be used in both backend and frontend applications.
 
-For frontend applications, it may not always be feasible or desirable to test against an actual API. In such cases, you can utilize a mocked Connect backend to test your application.
+## Mocking services
 
-### A simple mock for Eliza
-
-To illustrate, let's write a test for ELIZA that uses `createRouterTransport`:
-
-```ts
-import { createRouterTransport } from '@connectrpc/connect';
-import { ElizaService } from '@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect';
-import { SayResponse } from '@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_pb';
-
-export const mockElizaTransport = () =>
-  createRouterTransport(({ service }) => {
-    service(ElizaService, {
-      say: () => new SayResponse({ sentence: 'I feel happy.' })
-    });
-  });
-```
-
-In your client testing code, you can then use `createPromiseClient` from `@connectrpc/connect` with `mockElizaTransport`:
+The function `createRouterTransport` from `@connectrpc/connect` creates an in-memory
+server with your own RPC implementations. To illustrate, let's implement a very
+simple ELIZA service:
 
 ```ts
-import { createPromiseClient } from '@connectrpc/connect';
+import { ElizaService } from "@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect";
+import { SayResponse } from "@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_pb";
+import { createRouterTransport } from "@connectrpc/connect";
 
-describe('your client test suite', () => {
-  it('tests a simple client call', async () => {
-    const client = createPromiseClient(ElizaService, mockElizaTransport());
-    const { sentence } = await client.say({ sentence: 'how do you feel?' });
-    expect(sentence).toEqual('I feel happy');
+const mockTransport = createRouterTransport(({ service }) => {
+  service(ElizaService, {
+    say: () => new SayResponse({ sentence: "I feel happy." }),
   });
 });
 ```
 
-### Learning more about client testing
+In your tests, you can then use the `mockTransport` with the function
+`createPromiseClient` or `createCallbackClient`, just like you would use any other
+transport:
 
-See the Connect-Node documentation to learn about:
-- [how to mock a stateful server interaction](../node/testing.md#using-stateful-mocks-to-test-a-client)
-- [the motivations for not mocking fetch itself](../node/testing.md#what-about-mocking-fetch-itself)
-- [adding headers and trailers to your mock](../node/testing.md#adding-headers-interceptors-more)
-- [using (or testing) your interceptors](../node/testing.md#adding-headers-interceptors-more)
+```ts
+import { ElizaService } from "@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect";
+import { SayResponse } from "@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_pb";
+import { createRouterTransport, createPromiseClient } from "@connectrpc/connect";
+
+describe("simple ELIZA mock", function () {
+  const mockTransport = createRouterTransport(({ service }) => {
+    service(ElizaService, {
+      say: () => new SayResponse({ sentence: "I feel happy." }),
+    });
+  });
+  // highlight-next-line
+  it("returns mocked answer", async () => {
+    // highlight-next-line
+    const client = createPromiseClient(ElizaService, mockTransport);
+    // highlight-next-line
+    const { sentence } = await client.say({ sentence: "how do you feel?" });
+    // highlight-next-line
+    expect(sentence).toEqual("I feel happy.");
+  // highlight-next-line
+  });
+});
+```
+
+### Expectations in the service
+
+So far, we have only returned a mock response from our server, but we can also
+use expectations to assert that our client sends requests as expected:
+
+```ts
+const mockTransport = createRouterTransport(({ service }) => {
+  service(ElizaService, {
+    say(request) {
+      // highlight-next-line
+      expect(request.sentence).toBe("how do you feel?");
+      return new SayResponse({ sentence: "I feel happy." });
+    },
+  });
+});
+```
+
+
+### Raising errors
+
+Under the hood, the transport runs nearly the same code that a server running on
+Node.js would run. This means that all features from [implementing real services](../node/implementing-services.md)
+are available: You can access request headers, raise errors with details, and also
+mock streaming responses. Here is an example that raises an error on the fourth
+request:
+
+```ts
+const mockTransport = createRouterTransport(({ service }) => {
+  const sentences: string[] = [];
+  service(ElizaService, {
+    say(request: SayRequest) {
+      sentences.push(request.sentence);
+      if (sentences.length > 3) {
+        throw new ConnectError(
+          "I have no words anymore.",
+          Code.ResourceExhausted,
+        );
+      }
+      return new SayResponse({
+        sentence: `You said ${sentences.length} sentences.`,
+      });
+    },
+  });
+});
+```
+
+
+### Transport options
+
+Other transports take options like [interceptors](./interceptors.mdx). They can
+be passed to `createRouterTransport` in the optional second argument, an object
+with the property `transport` for transport options.
+
+
+### Jest and the jsdom environment
+
+If you are using [jest-environment-jsdom](https://www.npmjs.com/package/jest-environment-jsdom),
+you will very likely see an error when you run tests with the router transport,
+the protobuf binary format, or any other code relying on the otherwise widely
+available [encoding API](https://developer.mozilla.org/en-US/docs/Web/API/Encoding_API):
+
+```
+ReferenceError: TextEncoder is not defined
+```
+
+If you see this error, consider to use [@bufbuild/jest-environment-jsdom](https://www.npmjs.com/package/@bufbuild/jest-environment-jsdom)
+instead.
+
+
+### What about mocking `fetch` itself?
+
+Mocking `fetch` itself is a common approach to testing network requests, but it has some drawbacks. Instead, using a schema-based serialization chain with an in-memory transport can be a better approach. Here are some reasons why:
+
+- With schema-based serialization, the request goes through the same process as it would in your actual code, allowing you to test the full flow of your application.
+- You can create stateful mocks with an in-memory transport, which can test more complex workflows and scenarios.
+- An in-memory transport is fast, so you can quickly set up your tests without worrying about resetting mocks.
+- With an in-memory transport, you can eliminate the need for [spy functions](https://jestjs.io/docs/jest-object#jestspyonobject-methodname) because you can implement any checks directly in your server implementation. This can simplify your testing code and make it easier to understand.
+- You can leverage `expect` directly within the code of your mock implementation to verify particular scenarios pertaining to the requests or responses.
+
+
+## End-to-end testing
+
+[Playwright](https://playwright.dev/) is a powerful tool for testing complex web
+applications. It can intercept requests and return mocked responses to the web
+application under test. If you want to use Playwright with a Connect client, consider using
+[@connectrpc/connect-playwright](https://www.npmjs.com/package/@connectrpc/connect-playwright)
+to bring the type-safety of your schema to Playwright's [API Mocks](https://playwright.dev/docs/mock).
+
+A basic example:
+
+```ts
+test.describe("mocking Eliza", () => {
+  let mock: MockRouter;
+  test.beforeEach(({ context }) => {
+    mock = createMockRouter(context, {
+      baseUrl: "https://demo.connectrpc.com",
+    });
+  });
+  test("mock RPCs at service level", async ({ page }) => {
+    await mock.service(ElizaService, {
+      say: () => new SayResponse({ sentence: "I feel happy." }),
+    });
+    // Any calls to Eliza.Say in test code below will be intercepted and invoke
+    // the implementation above.
+  });
+});
+```
+
+To get started, take a look at the [connect-playwright repository](https://github.com/connectrpc/connect-playwright-es),
+and the [example project](https://github.com/connectrpc/connect-playwright-es/tree/main/packages/connect-playwright-example).


### PR DESCRIPTION
Our documentation for testing web applications with Connect is very short.

This PR replaces links to the Testing page in Connect for Node.js with examples for expections in the service, adding information about raising errors, stateful mocks, transport options, the jsdom environment, mcoking `fetch`, and e2e testing with playwright.

