### PR TITLE
Update Eliza references in Kotlin docs

### DIFF
--- a/docs/kotlin/generating-code.md
+++ b/docs/kotlin/generating-code.md
@@ -112,26 +112,24 @@ generated files in the `generated` directory:
 
 ```
 generated
-└── buf
-    └── connect
-        └── demo
-            └── eliza
-                └── v1
-                    ├── ConverseRequest.java
-                    ├── ConverseRequestOrBuilder.java
-                    ├── ConverseResponse.java
-                    ├── ConverseResponseOrBuilder.java
-                    ├── ElizaProto.java
-                    ├── ElizaServiceClient.kt
-                    ├── ElizaServiceClientInterface.kt
-                    ├── IntroduceRequest.java
-                    ├── IntroduceRequestOrBuilder.java
-                    ├── IntroduceResponse.java
-                    ├── IntroduceResponseOrBuilder.java
-                    ├── SayRequest.java
-                    ├── SayRequestOrBuilder.java
-                    ├── SayResponse.java
-                    └── SayResponseOrBuilder.java
+└── connectrpc
+    └── eliza
+        └── v1
+            ├── ConverseRequest.java
+            ├── ConverseRequestOrBuilder.java
+            ├── ConverseResponse.java
+            ├── ConverseResponseOrBuilder.java
+            ├── ElizaProto.java
+            ├── ElizaServiceClient.kt
+            ├── ElizaServiceClientInterface.kt
+            ├── IntroduceRequest.java
+            ├── IntroduceRequestOrBuilder.java
+            ├── IntroduceResponse.java
+            ├── IntroduceResponseOrBuilder.java
+            ├── SayRequest.java
+            ├── SayRequestOrBuilder.java
+            ├── SayResponse.java
+            └── SayResponseOrBuilder.java
 ```
 
 ## Using generated code

--- a/docs/kotlin/getting-started.md
+++ b/docs/kotlin/getting-started.md
@@ -70,19 +70,17 @@ it [hosted on the Buf Schema Registry][eliza-proto] to use in this example.
 Export the Protobuf schema to use in our project.
 
 ```bash title="~/.../Eliza/proto"
-$ buf export buf.build/bufbuild/eliza -o .
+$ buf export buf.build/connectrpc/eliza -o .
 ```
 
 Our new `proto` directory should look like this:
 
 ```
 proto
-├── buf
-│   └── connect
-│       └── demo
-│           └── eliza
-│               └── v1
-│                   └── eliza.proto
+├── connectrpc
+│   └── eliza
+│       └── v1
+│           └── eliza.proto
 └── buf.yaml
 ```
 
@@ -143,14 +141,12 @@ In the `app/src/main/java` directory, there should now be some generated Java an
 
 ```
 app/src/main/java
-├── buf
-│   └── connect
-│       └── demo
-│           └── eliza
-│               └── v1
-│                   ├── Eliza.java
-│                   ├── ElizaServiceClient.kt
-│                   └── ElizaServiceClientInterface.kt
+├── connectrpc
+│   └── eliza
+│       └── v1
+│           ├── Eliza.java
+│           ├── ElizaServiceClient.kt
+│           └── ElizaServiceClientInterface.kt
 └── com
     └── example
         └── eliza


### PR DESCRIPTION
Update Eliza references in the Kotlin docs to match the [Eliza module package](https://buf.build/connectrpc/eliza/file/main:connectrpc/eliza/v1/eliza.proto#L17)