### PR TITLE
Add vanity import for Vanguard

### DIFF
--- a/static/vanguard.html
+++ b/static/vanguard.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="go-import" content="connectrpc.com/vanguard git https://github.com/connectrpc/vanguard-go">
+        <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/connectrpc.com/vanguard">
+    </head>
+    <body>
+        API documentation for <code>connectrpc.com/vanguard</code>
+        is on <a href="https://pkg.go.dev/connectrpc.com/vanguard">pkg.go.dev</a>.
+    </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,11 @@
       "permanent": true
     },
     {
+      "source": "/vanguard/",
+      "destination": "/vanguard.html",
+      "permanent": true
+    },
+    {
       "source": "/docs/",
       "destination": "/docs/introduction",
       "permanent": true


### PR DESCRIPTION
Add a vanity import for `connectrpc.com/vanguard`. Shouldn't merge until the
Vanguard repository is public.
