### PR TITLE
Update all connect-kotlin BSR references

### DIFF
--- a/docs/kotlin/generating-code.md
+++ b/docs/kotlin/generating-code.md
@@ -74,7 +74,7 @@ file is shown below:
 ```yaml
 version: v1
 plugins:
-  - plugin: buf.build/bufbuild/connect-kotlin
+  - plugin: buf.build/connectrpc/kotlin
     out: generated
   - plugin: buf.build/protocolbuffers/java
     out: generated
@@ -159,7 +159,7 @@ The following generation options can be combined in the `opt` field of the `buf.
 [buf.yaml]: https://buf.build/docs/configuration/v1/buf-yaml
 [buf-cli]: https://buf.build/docs/installation
 [connect-kotlin]: https://github.com/bufbuild/connect-kotlin
-[connect-kotlin-plugin]: https://buf.build/bufbuild/connect-kotlin
+[connect-kotlin-plugin]: https://buf.build/connectrpc/kotlin
 [java-protobuf-plugin]: https://buf.build/protocolbuffers/java
 [protobuf]: https://developers.google.com/protocol-buffers
 [remote-plugins]: https://buf.build/docs/bsr/remote-plugins/usage

--- a/docs/kotlin/getting-started.md
+++ b/docs/kotlin/getting-started.md
@@ -111,7 +111,7 @@ version: v1
 plugins:
   - plugin: buf.build/protocolbuffers/java
     out: app/src/main/java
-  - plugin: buf.build/bufbuild/connect-kotlin
+  - plugin: buf.build/connectrpc/kotlin
     out: app/src/main/java
 ```
 
@@ -124,7 +124,7 @@ The above `buf.gen.yaml` config does two things:
    If the javalite option is desired, simply add `opt: javalite` to the yaml block.
    :::
 
-2. Executes the [bufbuild/connect-kotlin](https://buf.build/bufbuild/connect-kotlin) plugin to generates clients for
+2. Executes the [connectrpc/kotlin](https://buf.build/connectrpc/kotlin) plugin to generates clients for
    connect-kotlin. Compatible with the gRPC,
    gRPC-Web, and Connect RPC protocols into the specified directory. Connect is an RPC protocol which supports gRPC —
    including streaming! They interoperate seamlessly with Envoy, grpcurl, gRPC Gateway, and every other gRPC


### PR DESCRIPTION
Do not land until connect-kotlin plugin has been updated in the BSR