### PR TITLE
Update docs for Swift interceptors

### DIFF
--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -13,7 +13,7 @@ state, as well as to mutate outbound or inbound content.
 
 Every interceptor has the opportunity to perform asynchronous work before passing a potentially
 altered value to the next interceptor in the chain. When the end of the chain is reached, the
-final value is passed to the networking client where it is sent to the server (outbound request)
+final value is passed to the networking client, where it is sent to the server (outbound request)
 or to the caller (inbound response).
 
 Interceptors may also fail outbound requests before they're sent, thus preventing subsequent

--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -16,18 +16,18 @@ altered value to the next interceptor in the chain. When the end of the chain is
 final value is passed to the networking client, where it is sent to the server (outbound request)
 or to the caller (inbound response).
 
-Interceptors may also fail outbound requests before they are sent; subsequent 
+Interceptors may also fail outbound requests before they are sent; subsequent
 interceptors in the chain will not be invoked, and the error will be returned to the original caller.
 
-Interceptors are closure-based and receive both the current value and a closure that 
-should be called to resume the interceptor chain. Propagation will not continue until 
+Interceptors are closure-based and receive both the current value and a closure that
+should be called to resume the interceptor chain. Propagation will not continue until
 this closure is invoked. Additional values may still be passed to a given interceptor even
 though it has not yet continued the chain with a previous value. For example:
 
-- A request is sent
-- Response headers are received, and an interceptor pauses the chain while processing them
-- First chunk of streamed data is received, and the interceptor is invoked with this value
-- Interceptor is expected to resume with headers first, and then with data after
+1. A request is sent
+2. Response headers are received, and an interceptor pauses the chain while processing them
+3. The first chunk of streamed response data is received, and the interceptor is invoked with this value
+4. The interceptor is expected to resume with headers first, and then with data after
 
 Implementations should be thread-safe (hence the `Sendable` requirement on interceptor
 closures), as closures can be invoked from different threads during the span of a request or

--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -11,35 +11,80 @@ closures that are invoked by the client during the lifecycle of that request.
 Each closure provides the ability for the interceptor to observe and store
 state, as well as the option to mutate the outbound or inbound content.
 
+Each interceptor has the opportunity to perform asynchronous work before passing a potentially
+altered value to the next interceptor in the chain. When the end of the chain is reached, the
+final value is passed to the networking client where it is sent to the server or to the calling
+client.
+
+Interceptors may also fail outbound requests before they're sent, thus preventing subsequent
+interceptors from being invoked and returning a specified error back to the original caller.
+
+Interceptors are closure-based and are passed both the current value and a closure which
+should be called to resume the interceptor chain. Propagation will not continue until
+this closure is called. Additional values may still be passed to a given interceptor even
+though it has not yet continued the chain. For example:
+
+- Request is sent
+- Response headers are received, and an interceptor pauses the chain while processing
+- First chunk of streamed data is received, and the interceptor receives this value immediately
+- Interceptor is expected to resume headers first, followed by data
+
+Implementations should be thread-safe (hence the `Sendable` requirement on interceptor
+closures), as closures can be invoked from different threads during the span of a request or
+stream due to the asynchronous nature of other interceptors which may be present in the chain.
+
 For example, here is an interceptor that adds an `Authorization` header to
 all outbound requests that are destined for the `demo.connectrpc.com` host:
 
 ```swift
 import Connect
 
-/// Interceptor that adds an `Authorization` header to outbound
-/// requests to `demo.connectrpc.com`.
+/// Interceptor that asynchronously fetches an auth token and then adds an `Authorization`
+/// header to outbound requests to `demo.connectrpc.com`. If the token fetch fails, it rejects
+/// the outbound request and returns an error to the original caller.
 final class ExampleAuthInterceptor: Interceptor {
     init(config: ProtocolClientConfig) {}
 
     func unaryFunction() -> UnaryFunction {
         return UnaryFunction(
-            requestFunction: { request in
-                if request.url.host != "demo.connectrpc.com" {
-                    return request
+            requestFunction: { request, proceed in
+                guard request.url.host == "demo.connectrpc.com" else {
+                    // Allow the request to be sent as-is.
+                    proceed(.success(request))
+                    return
                 }
 
-                var headers = request.headers
-                headers["Authorization"] = ["SOME_USER_TOKEN"]
-                return HTTPRequest(
-                    url: request.url,
-                    contentType: request.contentType,
-                    headers: headers,
-                    message: request.message
-                )
+                fetchUserToken(forPath: request.url.path) { token in
+                    if let token = token {
+                        // Alter the request's headers and pass the request on to other interceptors
+                        // before eventually sending it to the server.
+                        var headers = request.headers
+                        headers["Authorization"] = ["Bearer \(token)"]
+                        proceed(.success(HTTPRequest(
+                            url: request.url,
+                            contentType: request.contentType,
+                            headers: headers,
+                            message: request.message,
+                            trailers: request.trailers
+                        )))
+                    } else {
+                        // Reject the request since no valid token was available, and
+                        // return an error to the caller.
+                        proceed(.failure(ConnectError(
+                            code: .unknown, message: "auth token fetch failed",
+                            exception: nil, details: [], metadata: [:]
+                        )))
+                    }
+                }
             },
-            responseFunction: { $0 }, // Return the response as-is
-            responseMetricsFunction: { $0 } // Can be used to observe metrics
+            responseFunction: { response, proceed in
+                // Can be used to read and/or alter the response.
+                proceed(response)
+            },
+            responseMetricsFunction: { metrics, proceed in
+                // Can be used to observe/track metrics.
+                proceed(metrics)
+            }
         )
     }
 

--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -16,8 +16,8 @@ altered value to the next interceptor in the chain. When the end of the chain is
 final value is passed to the networking client, where it is sent to the server (outbound request)
 or to the caller (inbound response).
 
-Interceptors may also fail outbound requests before they're sent, thus preventing subsequent
-interceptors from being invoked and returning a specified error back to the original caller.
+Interceptors may also fail outbound requests before they are sent; subsequent 
+interceptors in the chain will not be invoked, and the error will be returned to the original caller.
 
 Interceptors are closure-based and are passed both the current value and a closure which
 should be called to resume the interceptor chain. Propagation will not continue until

--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -6,15 +6,15 @@ sidebar_position: 5
 Interceptors are a powerful way to observe and mutate outbound and inbound
 headers, data, trailers, and errors both for unary APIs and streams.
 
-An interceptor is instantiated **once for each request** and provides a set of
-closures that are invoked by the client during the lifecycle of that request.
-Each closure provides the ability for the interceptor to observe and store
-state, as well as the option to mutate the outbound or inbound content.
+Each interceptor is instantiated **once per request or stream** and
+provides a set of closures that are invoked by the client during the lifecycle
+of that call. Each closure allows the interceptor to observe and store
+state, as well as to mutate outbound or inbound content.
 
-Each interceptor has the opportunity to perform asynchronous work before passing a potentially
+Every interceptor has the opportunity to perform asynchronous work before passing a potentially
 altered value to the next interceptor in the chain. When the end of the chain is reached, the
-final value is passed to the networking client where it is sent to the server or to the calling
-client.
+final value is passed to the networking client where it is sent to the server (outbound request)
+or to the caller (inbound response).
 
 Interceptors may also fail outbound requests before they're sent, thus preventing subsequent
 interceptors from being invoked and returning a specified error back to the original caller.
@@ -22,12 +22,12 @@ interceptors from being invoked and returning a specified error back to the orig
 Interceptors are closure-based and are passed both the current value and a closure which
 should be called to resume the interceptor chain. Propagation will not continue until
 this closure is called. Additional values may still be passed to a given interceptor even
-though it has not yet continued the chain. For example:
+though it has not yet continued the chain with a previous value. For example:
 
-- Request is sent
-- Response headers are received, and an interceptor pauses the chain while processing
-- First chunk of streamed data is received, and the interceptor receives this value immediately
-- Interceptor is expected to resume headers first, followed by data
+- A request is sent
+- Response headers are received, and an interceptor pauses the chain while processing them
+- First chunk of streamed data is received, and the interceptor is invoked with this value
+- Interceptor is expected to resume with headers first, and then with data after
 
 Implementations should be thread-safe (hence the `Sendable` requirement on interceptor
 closures), as closures can be invoked from different threads during the span of a request or

--- a/docs/swift/interceptors.md
+++ b/docs/swift/interceptors.md
@@ -19,9 +19,9 @@ or to the caller (inbound response).
 Interceptors may also fail outbound requests before they are sent; subsequent 
 interceptors in the chain will not be invoked, and the error will be returned to the original caller.
 
-Interceptors are closure-based and are passed both the current value and a closure which
-should be called to resume the interceptor chain. Propagation will not continue until
-this closure is called. Additional values may still be passed to a given interceptor even
+Interceptors are closure-based and receive both the current value and a closure that 
+should be called to resume the interceptor chain. Propagation will not continue until 
+this closure is invoked. Additional values may still be passed to a given interceptor even
 though it has not yet continued the chain with a previous value. For example:
 
 - A request is sent


### PR DESCRIPTION
Updates the documentation to reflect the changes in https://github.com/connectrpc/connect-swift/pull/186.

The copy matches `Interceptor.swift`'s inline documentation from that PR with the addition of an auth example here.