### PR TITLE
Make connectrpc.com/conformance go-gettable

### DIFF
--- a/static/conformance.html
+++ b/static/conformance.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="connectrpc.com/conformance git https://github.com/connectrpc/conformance"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://pkg.go.dev/connectrpc.com/conformance"
+    />
+  </head>
+  <body>
+    API documentation for <code>connectrpc.com/conformance</code> is on
+    <a href="https://pkg.go.dev/connectrpc.com/conformance">pkg.go.dev</a>.
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "trailingSlash": true,
   "redirects": [
     {
+      "source": "/conformance/",
+      "destination": "/conformance.html",
+      "permanent": true
+    },
+    {
       "source": "/connect/",
       "destination": "/connect.html",
       "permanent": true


### PR DESCRIPTION
Right now, the [conformance] repository is not go-gettable due to a missing redirect. While this repository may not be generally useful to go get, it is still useful as it allows running the conformance test servers via `go run`.

This PR adds a redirect akin to all of the other go-get redirects.

[conformance]: https://github.com/connectrpc/conformance