### PR TITLE
Fix occurrences of 'gRCP'

### DIFF
--- a/docs/node/using-clients.md
+++ b/docs/node/using-clients.md
@@ -90,7 +90,7 @@ The function `createGrpcWebTransport()` creates a Transport for the gRPC-web
 protocol. Any gRPC service can be made available to gRPC-web with the
 [Envoy Proxy](https://www.envoyproxy.io/). ASP.NET Core supports gRPC-web with
 a [middleware](https://docs.microsoft.com/en-us/aspnet/core/grpc/browser?view=aspnetcore-6.0).
-Connect for Node and `connect-go` support gRCP-web out of the box.
+Connect for Node and `connect-go` support gRPC-web out of the box.
 
 ```ts
 import { createGrpcWebTransport } from "@connectrpc/connect-node";

--- a/docs/web/cancellation-and-timeouts.mdx
+++ b/docs/web/cancellation-and-timeouts.mdx
@@ -63,7 +63,7 @@ When a timeout is reached before the request finishes, a `ConnectError` with
 code `DeadlineExceeded` is raised.
 
 When you specify a timeout, the value is sent to the server in a request header
-that is understood by Connect, gRCP, and gRPC-web servers. Servers _and_ clients
+that is understood by Connect, gRPC, and gRPC-web servers. Servers _and_ clients
 honor the timeout, which can be immensely helpful for streaming calls in a fragile
 network environment. Timeouts can also be propagated to upstream services.
 In gRPC, the concept is also known as [deadlines](https://grpc.io/docs/guides/deadlines/).

--- a/docs/web/choosing-a-protocol.mdx
+++ b/docs/web/choosing-a-protocol.mdx
@@ -55,7 +55,7 @@ The function `createGrpcWebTransport()` creates a Transport for the gRPC-web
 protocol. Any gRPC service can be made available to gRPC-web with the
 [Envoy Proxy](https://www.envoyproxy.io/). ASP.NET Core supports gRPC-web with
 a [middleware](https://docs.microsoft.com/en-us/aspnet/core/grpc/browser?view=aspnetcore-6.0).
-Connect for Node and `connect-go` support gRCP-web out of the box.
+Connect for Node and `connect-go` support gRPC-web out of the box.
 
 ```ts
 import { createGrpcWebTransport } from "@connectrpc/connect-web";


### PR DESCRIPTION
This fixes a few places in the docs that say `gRCP`.