### PR TITLE
Fix issue with workflow on forks

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -6,7 +6,7 @@ on:
       - opened
       - reopened
       - transferred
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened


### PR DESCRIPTION
This allows the add-to-project workflow to work on forks.