### PR TITLE
Add missing step to CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,7 +23,8 @@ clone the repository, and make your changes locally. If you have Node.js
 installed locally, you can preview your changes with `npm install && npm run
 start`. More complex changes may require consulting the
 [Docusaurus][docusaurus] documentation and understanding [this project's
-component swizzling][swizzling].
+component swizzling][swizzling]. When you're satisfied with your changes, [open
+a pull request](https://github.com/connectrpc/connectrpc.com/compare).
 
 At this point, you're waiting on us to review your changes. We *try* to respond
 to issues and pull requests within a few business days, and we may suggest some


### PR DESCRIPTION
In the description of how contributors should propose changes to the
documentation, I omitted the step where they actually open a pull
request.
