### PR TITLE
Add vanity import for connectrpc/conformance

### DIFF
--- a/static/conformance.html
+++ b/static/conformance.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="connectrpc.com/conformance git https://github.com/connectrpc/conformance"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://github.com/connectrpc/conformance#readme"
+    />
+  </head>
+  <body>
+    Documentation for <code>connectrpc.com/conformance</code> can be found on
+    <a href="https://github.com/connectrpc/conformance#readme">GitHub</a>.
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "trailingSlash": true,
   "redirects": [
     {
+      "source": "/conformance/",
+      "destination": "/conformance.html",
+      "permanent": true
+    },
+    {
       "source": "/connect/",
       "destination": "/connect.html",
       "permanent": true


### PR DESCRIPTION
Still unclear if we want to do this, since the conformance repo has no import-able Go code. But if we want to leave its `go.mod` and existing imports in the `v1` branch alone (which, for consistency, uses a connectrpc.com vanity domain like our other Connect Go packages) and make the test runner install-able via `go install ...`, we need this in place.