### PR TITLE
Remove stream from service definition

### DIFF
--- a/docs/go/get-requests-and-caching.md
+++ b/docs/go/get-requests-and-caching.md
@@ -25,7 +25,7 @@ must mark it as being side-effect free using the
 
 ```protobuf
 service ElizaService {
-  rpc Say(stream SayRequest) returns (SayResponse) {
+  rpc Say(SayRequest) returns (SayResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
   }
 }


### PR DESCRIPTION
GET requests are only supported via unary requests. This fixes the docs so that they show a unary service definition (instead of a client-streaming one).