### PR TITLE
Add redirect to catch other redirects

### DIFF
--- a/docs/web/query.mdx
+++ b/docs/web/query.mdx
@@ -1,6 +1,7 @@
 ---
 title: Connect for TanStack Query
 sidebar_position: 100
+slug: query/getting-started
 ---
 
 Connect-Query is a wrapper around [TanStack Query](https://tanstack.com/query) (formerly React Query), written in TypeScript and thoroughly tested. It enables effortless communication with servers that speak the [Connect Protocol](https://connectrpc.com/docs/protocol).


### PR DESCRIPTION
Our vercel.json currently specifies a `permanent` redirect from `/docs/web/query/` and `/web/query/` to `/docs/web/query/getting-started` which means we have to match that path name or 404s will through on full refresh.