### PR TITLE
Add Go module support for cors and authn

### DIFF
--- a/static/authn.html
+++ b/static/authn.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="connectrpc.com/authn git https://github.com/connectrpc/authn-go"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://pkg.go.dev/connectrpc.com/authn"
+    />
+  </head>
+  <body>
+    API documentation for <code>connectrpc.com/authn</code> is on
+    <a href="https://pkg.go.dev/connectrpc.com/authn">pkg.go.dev</a>.
+  </body>
+</html>

--- a/static/cors.html
+++ b/static/cors.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="connectrpc.com/cors git https://github.com/connectrpc/cors-go"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://pkg.go.dev/connectrpc.com/cors"
+    />
+  </head>
+  <body>
+    API documentation for <code>connectrpc.com/cors</code> is on
+    <a href="https://pkg.go.dev/connectrpc.com/cors">pkg.go.dev</a>.
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "trailingSlash": true,
   "redirects": [
     {
+      "source": "/authn/",
+      "destination": "/authn.html",
+      "permanent": true
+    },
+    {
       "source": "/conformance/",
       "destination": "/conformance.html",
       "permanent": true
@@ -9,6 +14,11 @@
     {
       "source": "/connect/",
       "destination": "/connect.html",
+      "permanent": true
+    },
+    {
+      "source": "/cors/",
+      "destination": "/cors.html",
       "permanent": true
     },
     {


### PR DESCRIPTION
Add the plumbing required to resolve the connectrpc.com/authn and
connectrpc.com/cors import paths (proposed and approved in #123).
