### PR TITLE
Fix Go observability options example

### DIFF
--- a/docs/go/observability.md
+++ b/docs/go/observability.md
@@ -61,11 +61,11 @@ When running multiple applications in a single binary, or if different sections 
 
 ```go
 // newInterceptor instruments Connect clients and handlers using custom OpenTelemetry metrics, tracing, and propagation.
-func newInterceptor(tp trace.TracerProvider, mp metric.MeterProvider, p propagation.TextMapPropagator) connect.Interceptor {
+func newInterceptor(tp trace.TracerProvider, mp metric.MeterProvider, p propagation.TextMapPropagator) (connect.Interceptor, error) {
 	return otelconnect.NewInterceptor(
 		otelconnect.WithTracerProvider(tp),
 		otelconnect.WithMeterProvider(mp),
-		otelconnect.WithTextMapPropagator(p),
+		otelconnect.WithPropagator(p),
 	)
 }
 ```


### PR DESCRIPTION
Correct the observability examples for the API changes. NewInterceptor now returns an error and the naming for the propagator is corrected.

Thanks to https://bufbuild.slack.com/archives/CRZ680FUH/p1705146367965609 for finding the issue.