### PR TITLE
Specification update for error code HTTP status

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -508,18 +508,18 @@ gRPC. Only the codes below are valid &mdash; there are no user-defined codes.
 
 | Code | HTTP Status | Description |
 | ---- | ----------- | ----------- |
-| `canceled` | 408 Request Timeout | RPC canceled, usually by the caller. |
+| `canceled` | 499 Client Closed Request | RPC canceled, usually by the caller. |
 | `unknown` | 500 Internal Server Error | Catch-all for errors of unclear origin and errors without a more appropriate code. |
 | `invalid_argument` | 400 Bad Request | Request is invalid, regardless of system state. |
-| `deadline_exceeded` | 408 Request Timeout | Deadline expired before RPC could complete or before the client received the response. |
+| `deadline_exceeded` | 504 Gateway Timeout | Deadline expired before RPC could complete or before the client received the response. |
 | `not_found` | 404 Not Found | User requested a resource (for example, a file or directory) that can't be found. |
 | `already_exists` | 409 Conflict | Caller attempted to create a resource that already exists. |
 | `permission_denied` | 403 Forbidden | Caller isn't authorized to perform the operation. |
 | `resource_exhausted` | 429 Too Many Requests | Operation can't be completed because some resource is exhausted. Use unavailable if the server is temporarily overloaded and the caller should retry later. |
-| `failed_precondition` | 412 Precondition Failed | Operation can't be completed because the system isn't in the required state. |
+| `failed_precondition` | 400 Bad Request | Operation can't be completed because the system isn't in the required state. |
 | `aborted` | 409 Conflict | The operation was aborted, often because of concurrency issues like a database transaction abort. |
 | `out_of_range` | 400 Bad Request | The operation was attempted past the valid range. |
-| `unimplemented` | 404 Not Found | The operation isn't implemented, supported, or enabled. |
+| `unimplemented` | 501 Not Implemented | The operation isn't implemented, supported, or enabled. |
 | `internal` | 500 Internal Server Error | An invariant expected by the underlying system has been broken. Reserved for serious errors. |
 | `unavailable` | 503 Service Unavailable | The service is currently unavailable, usually transiently. Clients should back off and retry idempotent operations. |
 | `data_loss` | 500 Internal Server Error | Unrecoverable data loss or corruption. |


### PR DESCRIPTION
This PR proposes updating the ConnectRPC specification to correct the following error code to HTTP status mappings. The new status codes map closer to the intended HTTP semantics and better align with the RPC ecosystem of codes, specifically those defined in [google/protobuf/code.proto](https://buf.build/googleapis/googleapis/file/main:google/rpc/code.proto).

| Code | Current HTTP Status | Proposed HTTP Status |
| --- | --- | --- |
| cancelled | 408 Request Timeout | 499 Client Closed Request |
| deadline_exceeded | 408 Request Timeout | 504 Gateway Timeout |
| failed_precondition | 412 Precondition Failed  | 400 Bad Request |
| unimplemented | 404 Not Found | 501 Not Implemented |

## Reasons for Proposed Changes

### [408 Request Timeout](https://www.rfc-editor.org/rfc/rfc9110.html#name-408-request-timeout)

The 408 HTTP status is not suitable for RPC errors. Current `cancelled` and `deadline_exceeded` aren’t applicable as the request body was not timed out. Additionally, the definition defines the client MAY repeat the request which is not the intended behaviour of either code.

### [412 Precondition Failed](https://www.rfc-editor.org/rfc/rfc9110.html#name-412-precondition-failed)

The 412 HTTP status indicates that HTTP headers specified in the request code, such as [`If-Unmodified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Unmodified-Since) or [`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match), were used to conditionally apply the request. This isn’t the defined behaviour of `failed_precondition` which states the system state is not valid for the request and is unrelated to header values.

### [404 Not Found](https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found)

The 404 HTTP status is used to indicate the resource doesn’t exist or the server doesn’t want to disclose the existence. For `unimplemented` a [501 Not Implemented](https://www.rfc-editor.org/rfc/rfc9110.html#name-501-not-implemented) is more applicable as that states that it’s the server that does not support the functionality required to fulfill the request not a resource issue.

### [499 Client Closed Request](https://web.archive.org/web/20170919111558/http://lxr.nginx.org/source/src/http/ngx_http_request.h)

The 499 HTTP status is a special case of the 502 Bad Gateway status code. It is adopted from the Nginx’s extended definition of 4XX errors to handle client errors. It indicates the client closed the connection whilst the server was still processing the request which aligns with the `canceled` error code's intent.

## Impact

The proposed changes will necessitate updates in each implementation. Fortunately, all existing ConnectRPC organization libraries decode error codes from the response body, irrespective of the HTTP status on valid payloads. This behavior ensures backward compatibility, allowing the libraries to seamlessly accommodate the newly specified HTTP statuses without any adverse effects.

Resolves #122 