### PR TITLE
Soften the language regarding error codes and HTTP codes with the Connect unary protocol

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -331,7 +331,7 @@ Errors are sent with a non-200 **HTTP-Status**. In those cases,
 omitted or a JSON-serialized [Error](#error-end-stream), possibly compressed
 using **Content-Encoding** and sent on the wire as the HTTP response content.
 Clients must not attempt to decompress zero-length HTTP response content. If 
-**Bare-Message** is an Error, **HTTP-Status** must match Error.code as specified 
+**Bare-Message** is an Error, **HTTP-Status** should match Error.code as specified
 in [the table below](#error-codes). When reading data from the wire, client 
 implementations must use the [HTTP-to-Connect mapping](#http-to-error-code) to infer a Connect 
 error code if **Bare-Message** is missing or malformed.


### PR DESCRIPTION
None of the actual client implementations require that the Connect RPC code and the HTTP code are aligned (which is actually good since it allowed us to improve the mappings (#130) without it being a breaking change in practice).

This updates the language in the spec to make it a little more clear that a client should not necessarily treat it as an error if the Connect RPC code and HTTP status code do not agree. Admittedly, this is a rather subtle single word change. We could be even more explicit about what clients should do. But I think that might be better saved for a future document that provides a more _behavior_-focused spec (vs. protocol/wire-format-focused), which can also include guidance and requirements about other things that are today only codified in [conformance test expectations](https://github.com/connectrpc/conformance/).