### PR TITLE
Fix minor inconsistencies in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -163,7 +163,7 @@ will return the wire error.
 Alternatively, if you wish to cancel the operation and immediately stop
 the client stream, see [below](#cancel-stream) to cancel the operation.
 
-### How do I cancel a client response stream in Connect-go?
+### How do I cancel a client response stream in connect-go?
 
 To cancel and abort a stream, call the cancel function of the underlying
 context associated with the stream. This context is provided on stream
@@ -239,7 +239,7 @@ docs that show how to configure CORS for their respective HTTP libraries.
 
 ### How does vanguard-go integrate with Connect interceptors?
 
-A [connect-go] handler wrapped with [Vanguard](https://github.com/connectrpc/vanguard-go)
+A `connect-go` handler wrapped with [Vanguard](https://github.com/connectrpc/vanguard-go)
 can use connect-go interceptors like
 any other connect-go handler, whether the incoming request is REST or one of the
 supported protocols. connect-go interceptors cannot be applied to gRPC handlers or


### PR DESCRIPTION
The FAQ is pretty consistent in the "connect-go" casing, so fixed one inconsistent instance. The FAQ goes back and forth on "connect-go" and "`connect-go`", though, so I did not make those consistent (not sure they need to be, though).
