### PR TITLE
Update React Native docs

### DIFF
--- a/docs/web/supported-browsers-and-frameworks.mdx
+++ b/docs/web/supported-browsers-and-frameworks.mdx
@@ -210,10 +210,8 @@ polyfillGlobal("Response", () => Response)
 ```
 
 Unfortunately, only unary requests via the [Connect protocol](../protocol.md) are supported in
-React Native due to some limitations in the above polyfills.
-
-If you would like to see improved support, please give us a +1 on [this issue](https://github.com/connectrpc/connect-es/issues/199)
-and we will prioritize it accordingly.
+React Native due to some limitations in React Native's implementation of the Fetch API. For more information, please see 
+[this issue](https://github.com/connectrpc/connect-es/issues/199)
 
 For a working example, see the [React Native project](https://github.com/connectrpc/examples-es/tree/main/react-native)
 in the [examples-es](https://github.com/connectrpc/examples-es) repo.


### PR DESCRIPTION
This updates the React Native docs snippet around streaming to simply link to the issue and not mention prioritization (since it's largely out of our hands at the moment).