### PR TITLE
Add stream connection timeout to go/streaming.md

### DIFF
--- a/docs/go/streaming.md
+++ b/docs/go/streaming.md
@@ -261,3 +261,15 @@ func (i *authInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 ```
 
 We apply our interceptor just as we did before, using `WithInterceptors`.
+
+## Stream Connection Timeout
+gRPC streams like tcp or websocket has connection timeout and need to be specified how long the connection would be alive. To set the connection timeout configuration set the `IdleTimeout` to your `&http.Server{}` instance.
+Example:
+
+```go
+server := &http.Server{
+  // IdleTimeout:  0,
+  // IdleTimeout:  1 * time.Minute,
+}
+```
+Zero idle timeout means connection would be alive until you close it, no timeout really.


### PR DESCRIPTION
Hi, I added server connection timeout configuration example to `go/streaming.md` and i think it's useful when new developers use connectrpc and find out connections die after 3 or 4 seconds. The same thing happend to me, i said why not share in document and makes it more straight forward to use?