### PR TITLE
Update docs to pin to v1.x for Protobuf-ES

### DIFF
--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -34,7 +34,7 @@ $ cd connect-example
 $ npm init -y
 $ npm install typescript tsx
 $ npx tsc --init
-$ npm install @bufbuild/buf @bufbuild/protoc-gen-es @bufbuild/protobuf @connectrpc/protoc-gen-connect-es @connectrpc/connect
+$ npm install @bufbuild/buf @bufbuild/protoc-gen-es@"^1.10.0" @bufbuild/protobuf@"^1.10.0" @connectrpc/protoc-gen-connect-es @connectrpc/connect
 ```
 
 ## Define a service

--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -34,7 +34,7 @@ $ cd connect-example
 $ npm init -y
 $ npm install typescript tsx
 $ npx tsc --init
-$ npm install @bufbuild/buf @bufbuild/protoc-gen-es@"^1.10.0" @bufbuild/protobuf@"^1.10.0" @connectrpc/protoc-gen-connect-es @connectrpc/connect
+$ npm install @bufbuild/buf @bufbuild/protoc-gen-es@"^1.0.0" @bufbuild/protobuf@"^1.0.0" @connectrpc/protoc-gen-connect-es@"^1.0.0" @connectrpc/connect@"^1.0.0"
 ```
 
 ## Define a service

--- a/docs/node/server-plugins.md
+++ b/docs/node/server-plugins.md
@@ -55,7 +55,7 @@ with your Connect RPCs. Use the plugin from [@connectrpc/connect-fastify](https:
 with Fastify:
 
 ```bash
-$ npm install fastify @connectrpc/connect @connectrpc/connect-node @connectrpc/connect-fastify
+$ npm install fastify @connectrpc/connect@"^1.0.0" @connectrpc/connect-node@"^1.0.0" @connectrpc/connect-fastify@"^1.0.0"
 ```
 
 ```ts
@@ -101,7 +101,7 @@ using the latest React features. With [@connectrpc/connect-next](https://www.npm
 you can serve your Connect RPCs via Next.js API Routes.
 
 ```bash
-$ npm install next @connectrpc/connect @connectrpc/connect-node @connectrpc/connect-next
+$ npm install next @connectrpc/connect@"^1.0.0" @connectrpc/connect-node@"^1.0.0" @connectrpc/connect-next@"^1.0.0"
 ```
 
 To enable the server plugin, create the file `pages/api/[[...connect]].ts` in your project:
@@ -143,7 +143,7 @@ popular because of its simplicity. Use the middleware provided by [@connectrpc/c
 to add your Connect RPCs to Express:
 
 ```bash
-$ npm install express @connectrpc/connect @connectrpc/connect-node @connectrpc/connect-express
+$ npm install express @connectrpc/connect@"^1.0.0" @connectrpc/connect-node@"^1.0.0" @connectrpc/connect-express@"^1.0.0"
 ```
 
 ```ts

--- a/docs/node/server-plugins.md
+++ b/docs/node/server-plugins.md
@@ -101,7 +101,7 @@ using the latest React features. With [@connectrpc/connect-next](https://www.npm
 you can serve your Connect RPCs via Next.js API Routes.
 
 ```bash
-$ npm install next @connectrpc/connect@"^1.0.0" @connectrpc/connect-node@"^1.0.0" @connectrpc/connect-next@"^1.0.0"
+$ npm install next@"^13.0.0" @connectrpc/connect@"^1.0.0" @connectrpc/connect-node@"^1.0.0" @connectrpc/connect-next@"^1.0.0"
 ```
 
 To enable the server plugin, create the file `pages/api/[[...connect]].ts` in your project:

--- a/docs/web/generating-code.mdx
+++ b/docs/web/generating-code.mdx
@@ -69,8 +69,8 @@ The code we will generate has three runtime dependencies:
 First, let's install `buf`, the plugins and runtime dependencies:
 
 ```bash
-$ npm install --save-dev @bufbuild/buf @connectrpc/protoc-gen-connect-es @bufbuild/protoc-gen-es@"^1.10.0"
-$ npm install @connectrpc/connect @connectrpc/connect-web @bufbuild/protobuf@"^1.10.0"
+$ npm install --save-dev @bufbuild/buf @connectrpc/protoc-gen-connect-es@"^1.0.0" @bufbuild/protoc-gen-es@"^1.0.0"
+$ npm install @connectrpc/connect@"^1.0.0" @connectrpc/connect-web@"^1.0.0" @bufbuild/protobuf@"^1.0.0"
 ```
 
 Next, tell Buf to use the two plugins with a new configuration file:

--- a/docs/web/generating-code.mdx
+++ b/docs/web/generating-code.mdx
@@ -69,8 +69,8 @@ The code we will generate has three runtime dependencies:
 First, let's install `buf`, the plugins and runtime dependencies:
 
 ```bash
-$ npm install --save-dev @bufbuild/buf @connectrpc/protoc-gen-connect-es @bufbuild/protoc-gen-es
-$ npm install @connectrpc/connect @connectrpc/connect-web @bufbuild/protobuf
+$ npm install --save-dev @bufbuild/buf @connectrpc/protoc-gen-connect-es @bufbuild/protoc-gen-es@"^1.10.0"
+$ npm install @connectrpc/connect @connectrpc/connect-web @bufbuild/protobuf@"^1.10.0"
 ```
 
 Next, tell Buf to use the two plugins with a new configuration file:

--- a/docs/web/getting-started.mdx
+++ b/docs/web/getting-started.mdx
@@ -51,7 +51,7 @@ the types we need on the fly:
 
 ```bash
 $ npm config set @buf:registry https://buf.build/gen/npm/v1
-$ npm install @buf/connectrpc_eliza.bufbuild_es@1.10.0-20230913231627-233fca715f49.1 @connectrpc/connect@"^v1.0.0" @connectrpc/connect-web@"^v1.0.0"
+$ npm install @buf/connectrpc_eliza.connectrpc_es@1.4.0-20230913231627-233fca715f49.3 @connectrpc/connect@"^v1.0.0" @connectrpc/connect-web@"^v1.0.0"
 ```
 
 (You can generate code locally if you prefer. We'll explain remote and local

--- a/docs/web/getting-started.mdx
+++ b/docs/web/getting-started.mdx
@@ -51,7 +51,7 @@ the types we need on the fly:
 
 ```bash
 $ npm config set @buf:registry https://buf.build/gen/npm/v1
-$ npm install @buf/connectrpc_eliza.connectrpc_es @connectrpc/connect @connectrpc/connect-web
+$ npm install @buf/connectrpc_eliza.bufbuild_es@1.10.0-20230913231627-233fca715f49.1 @connectrpc/connect@"^v1.0.0" @connectrpc/connect-web@"^v1.0.0"
 ```
 
 (You can generate code locally if you prefer. We'll explain remote and local
@@ -241,7 +241,7 @@ We ran the following commands to build the app:
 $ npm create vite@latest -- connect-example --template react-ts
 $ cd connect-example
 $ npm config set @buf:registry https://buf.build/gen/npm/v1
-$ npm install @buf/connectrpc_eliza.connectrpc_es @connectrpc/connect @connectrpc/connect-web
+$ npm install @buf/connectrpc_eliza.connectrpc_es@1.4.0-20230913231627-233fca715f49.3 @connectrpc/connect@"^1.0.0" @connectrpc/connect-web@"^1.0.0"
 $ npm run dev
 ```
 

--- a/docs/web/query.mdx
+++ b/docs/web/query.mdx
@@ -9,7 +9,7 @@ Connect-Query is a wrapper around [TanStack Query](https://tanstack.com/query) (
 ### Install
 
 ```sh
-npm install @connectrpc/connect-query @connectrpc/connect-web
+npm install @connectrpc/connect-query@"^1.0.0" @connectrpc/connect-web@"^1.0.0"
 ```
 
 ### Usage


### PR DESCRIPTION
Currently, installing Protobuf-ES and Connect without specifying a version will fail because it will try to install v2.0 of Protobuf-ES and v1.0 of Connect. This updates the docs to pin _all_ dependences to `^1.0.0`.

Note that we should update these when a v2.0 of Connect is released. 