### PR TITLE
Fix RN Polyfills instructions for release builds

### DIFF
--- a/docs/web/supported-browsers-and-frameworks.mdx
+++ b/docs/web/supported-browsers-and-frameworks.mdx
@@ -203,7 +203,13 @@ import { ReadableStream } from "web-streams-polyfill"
 polyfillGlobal("ReadableStream", () => ReadableStream)
 polyfillGlobal("TextDecoder", () => TextEncoder)
 polyfillGlobal("TextEncoder", () => TextEncoder)
-polyfillGlobal("fetch", () => fetch)
+polyfillGlobal(
+  "fetch", () => (...args) => fetch(args[0], { 
+    ...args[1], 
+    // Inject textStreaming: https://github.com/react-native-community/fetch/issues/15
+    reactNative: { textStreaming: true }
+  }),
+)
 polyfillGlobal("Headers", () => Headers)
 polyfillGlobal("Request", () => Request)
 polyfillGlobal("Response", () => Response)


### PR DESCRIPTION
The RN polyfill updates in https://github.com/connectrpc/connectrpc.com/pull/182 work great for debug builds but have an issue in release builds. This updates the instructions to rectify this oversight.