### PR TITLE
Fix docs correct error handling in golang Headers & trailers section

### DIFF
--- a/docs/go/headers-and-trailers.md
+++ b/docs/go/headers-and-trailers.md
@@ -75,7 +75,7 @@ func call() {
     connect.NewRequest(&greetv1.GreetRequest{}),
   )
   if connectErr := new(connect.Error); errors.As(err, &connectErr) {
-    fmt.Println(err.Meta().Get("Greet-Version"))
+    fmt.Println(connectErr.Meta().Get("Greet-Version"))
   }
 }
 ```


### PR DESCRIPTION
### Summary

This PR fixes a minor issue in the documentation's error handling example. The original example incorrectly referenced `err` instead of `connectErr` when accessing metadata, which could lead to confusion.

### Changes
- Updated the error handling example to correctly use `connectErr.Meta().Get("Greet-Version")` instead of `err.Meta().Get("Greet-Version")`.
