### PR TITLE
Migrate to v2 for Connect and Protobuf-ES

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "connect-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@buf/connectrpc_eliza.connectrpc_es": "^1.1.2-20230726230109-bf1eaaff2a44.1",
-        "@bufbuild/protobuf": "^1.10.0",
-        "@connectrpc/connect": "^1.4.0",
-        "@connectrpc/connect-web": "^1.4.0",
+        "@buf/connectrpc_eliza.bufbuild_es": "^2.2.2-20230913231627-233fca715f49.2",
+        "@bufbuild/protobuf": "^2.2.2",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-web": "^2.0.0",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/plugin-google-gtag": "^3.5.2",
         "@docusaurus/preset-classic": "^3.5.2",
@@ -2353,20 +2353,10 @@
       }
     },
     "node_modules/@buf/connectrpc_eliza.bufbuild_es": {
-      "version": "1.3.3-20230913231627-233fca715f49.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.bufbuild_es/-/connectrpc_eliza.bufbuild_es-1.3.3-20230913231627-233fca715f49.2.tgz",
+      "version": "2.2.2-20230913231627-233fca715f49.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.bufbuild_es/-/connectrpc_eliza.bufbuild_es-2.2.2-20230913231627-233fca715f49.2.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.3.3"
-      }
-    },
-    "node_modules/@buf/connectrpc_eliza.connectrpc_es": {
-      "version": "1.1.2-20230913231627-233fca715f49.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/connectrpc_eliza.connectrpc_es/-/connectrpc_eliza.connectrpc_es-1.1.2-20230913231627-233fca715f49.3.tgz",
-      "dependencies": {
-        "@buf/connectrpc_eliza.bufbuild_es": "1.3.3-20230913231627-233fca715f49.2"
-      },
-      "peerDependencies": {
-        "@connectrpc/connect": "^1.1.2"
+        "@bufbuild/protobuf": "^2.2.2"
       }
     },
     "node_modules/@bufbuild/license-header": {
@@ -2383,9 +2373,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
-      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.2.2.tgz",
+      "integrity": "sha512-UNtPCbrwrenpmrXuRwn9jYpPoweNXj8X5sMvYgsqYyaH8jQ6LfUJSk3dJLnBK+6sfYPrF4iAIo5sd5HQ+tg75A==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@colors/colors": {
@@ -2399,22 +2389,22 @@
       }
     },
     "node_modules/@connectrpc/connect": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.5.0.tgz",
-      "integrity": "sha512-1gGg0M6c2Y3lnr5itis9dNj9r8hbOIuBMqoGSbUy7L7Vjw4MAttjJzJfj9HCDgytGCJkGanYEYI6MQVDijdVQw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0.tgz",
+      "integrity": "sha512-Usm8jgaaULANJU8vVnhWssSA6nrZ4DJEAbkNtXSoZay2YD5fDyMukCxu8NEhCvFzfHvrhxhcjttvgpyhOM7xAQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0"
+        "@bufbuild/protobuf": "^2.2.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.5.0.tgz",
-      "integrity": "sha512-xjiiQ932Kibddaka18fGZ6yQL7xjXuLcYFYh/cU+q1WWEIrFPkZfViG/Ee6yrZbrlZkjcBuDibng+q7baTndfg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0.tgz",
+      "integrity": "sha512-oeCxqHXLXlWJdmcvp9L3scgAuK+FjNSn+twyhUxc8yvDbTumnt5Io+LnBzSYxAdUdYqTw5yHfTSCJ4hj0QID0g==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0",
-        "@connectrpc/connect": "1.5.0"
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "publish": "npm install && npm run lint && npm run check:types && npm run build"
   },
   "dependencies": {
-    "@buf/connectrpc_eliza.connectrpc_es": "^1.1.2-20230726230109-bf1eaaff2a44.1",
-    "@bufbuild/protobuf": "^1.10.0",
-    "@connectrpc/connect": "^1.4.0",
-    "@connectrpc/connect-web": "^1.4.0",
+    "@buf/connectrpc_eliza.bufbuild_es": "^2.2.2-20230913231627-233fca715f49.2",
+    "@bufbuild/protobuf": "^2.2.2",
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-web": "^2.0.0",
     "@docusaurus/core": "^3.5.2",
     "@docusaurus/plugin-google-gtag": "^3.5.2",
     "@docusaurus/preset-classic": "^3.5.2",

--- a/src/components/eliza-demo/index.tsx
+++ b/src/components/eliza-demo/index.tsx
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ElizaService } from "@buf/connectrpc_eliza.connectrpc_es/connectrpc/eliza/v1/eliza_connect";
+import { ElizaService } from "@buf/connectrpc_eliza.bufbuild_es/connectrpc/eliza/v1/eliza_pb";
 import React, { useCallback, useState } from "react";
-import { createPromiseClient } from "@connectrpc/connect";
+import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { Terminal, Message } from "../terminal";
 
@@ -24,7 +24,7 @@ const transport = createConnectTransport({
   baseUrl: host,
 });
 
-const elizaServicePromiseClient = createPromiseClient(ElizaService, transport);
+const elizaServicePromiseClient = createClient(ElizaService, transport);
 
 interface DemoProps {
   focusOnMount?: boolean;


### PR DESCRIPTION
This migrates the repo to use the v2 releases of Protobuf-ES and Connect.