### PR TITLE
Add additional options for generating imports

### DIFF
--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -104,8 +104,6 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: gen
-    # Also generate any well-known type dependencies
-    include_wkt: true
     # Also generate any imported dependencies
     include_imports: true
     opt: target=ts

--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -104,6 +104,10 @@ version: v2
 plugins:
   - local: protoc-gen-es
     out: gen
+    # Also generate any well-known type dependencies
+    include_wkt: true
+    # Also generate any imported dependencies
+    include_imports: true
     opt: target=ts
 ```
 

--- a/docs/web/generating-code.mdx
+++ b/docs/web/generating-code.mdx
@@ -82,8 +82,6 @@ plugins:
   # This will invoke protoc-gen-es and write output to src/gen
   - local: protoc-gen-es
     out: src/gen
-    # Also generate any well-known type dependencies
-    include_wkt: true
     # Also generate any imported dependencies
     include_imports: true
     # Add more plugin options here

--- a/docs/web/generating-code.mdx
+++ b/docs/web/generating-code.mdx
@@ -82,6 +82,10 @@ plugins:
   # This will invoke protoc-gen-es and write output to src/gen
   - local: protoc-gen-es
     out: src/gen
+    # Also generate any well-known type dependencies
+    include_wkt: true
+    # Also generate any imported dependencies
+    include_imports: true
     # Add more plugin options here
     opt: target=ts
 ```


### PR DESCRIPTION
Including imports is not enabled by default in the Buf CLI. As a result, users have been getting tripped up on generating code when they have dependencies on protovalidate. 

This adds some additional guidance in our generating code docs to make sure they include imports since these should essentially always be included when generating with Protobuf-ES.