### PR TITLE
Fix unary example HTTP status in protocol.md

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -398,7 +398,7 @@ The same RPC again, but with a Protobuf-encoded request and an error response:
 >
 > <uncompressed binary Protobuf>
 
-< HTTP/1.1 404 Not Found
+< HTTP/1.1 501 Not Implemented
 < Content-Type: application/json
 <
 < {


### PR DESCRIPTION
The protocol spec gives the following example for a unary error response:

```
HTTP/1.1 404 Not Found
Content-Type: application/json

{
  "code": "unimplemented",
  "message": "connectrpc.greet.v1.GreetService/Greet is not implemented"
}
```

After the amendment to HTTP codes from https://github.com/connectrpc/connectrpc.com/pull/130, this example is incorrect. For the Connect code `unimplemented`, the HTTP status code must be 501 Not Implemented.

