### PR TITLE
Make accept-encoding format more clear

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -175,16 +175,17 @@ generated clients, should send this header. Servers and proxies may reject
 traffic without this header with an HTTP status code of 400.
 
 Following standard HTTP semantics, servers must assume "identity" if the client
-omits **Content-Encoding**. If the client omits **Accept-Encoding**, servers
-must assume that the client accepts the **Content-Encoding** used for the
-request. Servers must assume that all clients accept "identity" as their least
-preferred encoding. Server implementations may choose to accept the full HTTP
-quality value syntax for **Accept-Encoding**, but client implementations must
-restrict themselves to sending the easy-to-parse subset outlined here. Servers
-should treat **Accept-Encoding** as an ordered list, with the client's most
-preferred encoding first and least preferred encoding last. If the client uses
-an unsupported **Content-Encoding**, servers should return an error with code
-"unimplemented" and a message listing the supported encodings.
+omits **Content-Encoding**.
+
+If the client omits **Accept-Encoding**, servers must assume that the client
+accepts the **Content-Encoding** used for the request if present. Servers must
+assume that all clients accept "identity" as their least preferred encoding,
+even when **Accept-Encoding** is omitted. Servers should treat **Accept-Encoding**
+as an ordered list, with the client's most preferred encoding first and least
+preferred encoding last. This is a simplification fo standard HTTP semantics
+that excludes quality values. If the client uses an unsupported **Content-Encoding**,
+servers should return an error with code "unimplemented" and a message listing the
+supported encodings.
 
 If **Timeout** is omitted, the server should assume an infinite timeout. The
 protocol accommodates timeouts of more than 100 days. Client implementations


### PR DESCRIPTION
I was trying to fully understand the spec for accept-encoding and found a couple of confusing points this tries to fix

- Missing `Content-Encoding` is only about request compression. Being in the same paragraph as handling `Accept-Encoding`, it felt like it was also being applied to response compression. I separated paragraphs to try to make this clearer

- I removed the notion of accepting full HTTP quality values. I feel that if even connect-go [doesn't](https://github.com/connectrpc/connect-go/blob/main/protocol.go#L332), then it's not worth mentioning here. It would be better if semicolon is handled and qualities are ignored, but if they'll just parse incorrectly, and clients are required to not use it anyways, there seems no real case for it on the server side. While I suspect it may be about HTTP proxies, in the end if a non-compliant server will just ignore the encodings completely due to just parsing by comma, it seems moot. But if this seems more a bug in connect-go and not the spec, I'll restore that