### PR TITLE
Add RFC 005: Python

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,12 +5,14 @@ Connect implementations:
 
 - [connect-go][go],
 - [connect-es][es],
-- [connect-swift][swift], 
-- [connect-kotlin][kotlin], and
-- [connect-dart][dart].
+- [connect-swift][swift],
+- [connect-kotlin][kotlin],
+- [connect-dart][dart], and
+- [connect-python][python].
 
 [go]: https://github.com/connectrpc/connect-go/blob/main/MAINTAINERS.md
 [es]: https://github.com/connectrpc/connect-es/blob/main/MAINTAINERS.md
 [swift]: https://github.com/connectrpc/connect-swift/blob/main/MAINTAINERS.md
 [kotlin]: https://github.com/connectrpc/connect-kotlin/blob/main/MAINTAINERS.md
 [dart]: https://github.com/connectrpc/connect-dart/blob/main/MAINTAINERS.md
+[python]: https://github.com/connectrpc/connect-python/blob/main/MAINTAINERS.md

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -30,7 +30,7 @@ In order to make incremental progress, we explicitly cross off certain features 
 
 gRPC is a poor match to Python's most commonly used asynchronous server framework, ASGI.
 A correct gRPC implementation requires control over very low-level details of the connection state and http/2 transport.
-These details are not exposed by ASGI, so supporting them would prevent connect-python's servers from being ASGI applications.
+These details are not exposed by ASGI, so supporting them would prevent this library's servers from being ASGI applications.
 
 That's an unacceptable trade-off to make because ASGI interoperability is important for integrating connect servers into larger applications, like those running on Django, Starlette or FastAPI.
 
@@ -87,9 +87,9 @@ features:
 
 ## General design
 
-Most of the code for both servers and clients will be in a connect-python runtime library, installable with `pip install connect-python`.
+Most of the code for both servers and clients will be in a runtime library, installable with `pip install connectrpc`.
 
-A code generator, written in Python and installable with `pip install connect-python[compiler]`, will be available to generate a few functions:
+A code generator, written in Python and installable with `pip install connectrpc[compiler]`, will be available to generate a few functions:
 
 1. Synchronous and asynchronous client constructors
 2. Synchronous and asynchronous `typing.Protocol` that defines the method set that server implementations must follow

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -26,7 +26,7 @@ In order to make incremental progress, we explicitly cross off certain features 
 1. *No cross-protocol support*: this will only be a client and server of the Connect protocol, not gRPC or grpc-web.
 2. *No full-duplex streams*: http/2 transport is hard to support on both client and server; half-duplex is fine though
 
-### Justification for only supporting Connect on the server
+### Justification for not supporting gRPC on the server
 
 gRPC is a poor match to Python's most commonly used asynchronous server framework, ASGI.
 A correct gRPC implementation requires control over very low-level details of the connection state and http/2 transport.
@@ -34,7 +34,7 @@ These details are not exposed by ASGI, so supporting them would prevent connect-
 
 That's an unacceptable trade-off to make because ASGI interoperability is important for integrating connect servers into larger applications, like those running on Django, Starlette or FastAPI.
 
-### Justification for only supporting Connect on the client
+### Justification for not supporting gRPC on the client
 
 Implementing a correct gRPC client again requires low-level control over the transport stack.
 The connect client would need to accept an extremely low-level and generic transport, even when contacting connect servers, just to support gRPC.
@@ -43,9 +43,21 @@ This is more acceptable than the server case, but still unpleasant.
 Users will expect that they can pass an httpx.Client or similar to configure instrumentation, authentication, and so on.
 If we use a low-level library like hyper-h2 to implement the client, we'd likely need to build a bespoke abstraction supporting features like authentication which would be quite a bit more scope to cover.
 
+### Justification for not support grpc-web
+
+The grpc-web project lacks a standalone specification.
+It is defined [only in relation to gRPC](https://github.com/grpc/grpc/blob/6c7e2a94f99747950397258a8de005a3d90210a1/doc/PROTOCOL-WEB.md).
+
+As a result, most Connect implementations of grpc-web do so by treating it as a special case of gRPC.
+But without a gRPC implementation to base off of, a Python Connect library would need to implement grpc-web "from scratch" which is much more complex.
+
+The benefits of doing this are outweighed by its complexity for now.
+grpc-web users choose it because it is compatible with browsers, but so is Connect.
+grpc-web could be a useful later addition to the features provided by a Python implementation, but it need not be in the initial implementation.
+
 ### Justification for only supporting half-duplex streams
 
-This is related to the above two justifications: http/2 is poorly supported in Python today.
+This is related to the previous justifications on gRPC: http/2 is poorly supported in Python today.
 
 ## Goals
 

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -124,4 +124,4 @@ class ElizaServiceClient:
 
 The `UnaryOutput` and `StreamOutput` generic wrapper types provide access to response headers, trailers, and Connect protocol errors, as well as the wrapped message.
 
-Analagous methods would be available on the asynchronous client.
+Analogous methods would be available on the asynchronous client.

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -124,4 +124,11 @@ class ElizaServiceClient:
 
 The `UnaryOutput` and `StreamOutput` generic wrapper types provide access to response headers, trailers, and Connect protocol errors, as well as the wrapped message.
 
-Analogous methods would be available on the asynchronous client.
+Analagous methods would be available on the asynchronous client.
+
+## Maintainers
+
+The project can be maintained by:
+
+- [Spencer Nelson](https://github.com/spenczar), [Firetiger](https://firetiger.com)
+- [Peter Edge](https://github.com/bufdev), [Buf](https://buf.build)

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -43,7 +43,7 @@ This is more acceptable than the server case, but still unpleasant.
 Users will expect that they can pass an httpx.Client or similar to configure instrumentation, authentication, and so on.
 If we use a low-level library like hyper-h2 to implement the client, we'd likely need to build a bespoke abstraction supporting features like authentication which would be quite a bit more scope to cover.
 
-### Justification for not support grpc-web
+### Justification for not supporting grpc-web
 
 The grpc-web project lacks a standalone specification.
 It is defined [only in relation to gRPC](https://github.com/grpc/grpc/blob/6c7e2a94f99747950397258a8de005a3d90210a1/doc/PROTOCOL-WEB.md).

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -15,7 +15,7 @@ The Python ecosystem has a big split between asynchronous and synchronous I/O, w
 Supporting both is important; Python applications tend to commit to one of the two sides of the split and have difficulty using the other.
 
 Further complicating matters is the Python community is divided regarding the right asynchronous implementation.
-[asyncio](https://docs.python.org/3/library/asyncio.html) is the standard library's answer, but you can find adherents of [https://trio.readthedocs.io/en/stable/](trio) and other asynchronous event loops.
+[asyncio](https://docs.python.org/3/library/asyncio.html) is the standard library's answer, but you can find adherents of [trio](https://trio.readthedocs.io/en/stable/) and other asynchronous event loops.
 
 Python's immature support for http/2 is also a major challenge, particularly for servers.
 

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -143,4 +143,4 @@ Analagous methods would be available on the asynchronous client.
 The project can be maintained by:
 
 - [Spencer Nelson](https://github.com/spenczar), [Firetiger](https://firetiger.com)
-- [Peter Edge](https://github.com/bufdev), [Buf](https://buf.build)
+- [Stefan VanBuren](https://github.com/stefanvanburen), [Buf](https://buf.build)

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -99,7 +99,7 @@ In certain circumstances, they can also inspect or send trailers.
 Full support of this is enforced by the conformance test suite.
 
 But these advanced features can cloud the API for typical usage.
-Headers and trailers are uinused in the majority of RPC usage; the RPC's message types typically encode all the relevant information.
+Headers and trailers are unused in the majority of RPC usage; the RPC's message types typically encode all the relevant information.
 
 So, we will provide clients with both high-level simple methods which operate directly on the request and response types, and also low-level methods that wrap request and response types in classes that permit handling of headers and trailers.
 

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -1,0 +1,127 @@
+# 005: Python Implementation
+
+I propose an official Python implementation of Connect, based on the prototype at https://github.com/firetiger-oss/connect-python/.
+This should include both the client and server side.
+
+## Why
+
+Python is a major language used heavily in web development.
+Adding an official implementation will help the Connect community focus its efforts.
+
+## Anticipated Complications
+
+
+The Python ecosystem has a big split between asynchronous and synchronous I/O, which will complicate the implementation story.
+Supporting both is important; Python applications tend to commit to one of the two sides of the split and have difficulty using the other.
+
+Further complicating matters is the Python community is divided regarding the right asynchronous implementation.
+[asyncio](https://docs.python.org/3/library/asyncio.html) is the standard library's answer, but you can find adherents of [https://trio.readthedocs.io/en/stable/](trio) and other asynchronous event loops.
+
+Python's immature support for http/2 is also a major challenge, particularly for servers.
+
+## Non-goals
+
+In order to make incremental progress, we explicitly cross off certain features in the initial pass at a Python implementation:
+
+1. *No cross-protocol support*: this will only be a client and server of the Connect protocol, not gRPC or grpc-web.
+2. *No full-duplex streams*: http/2 transport is hard to support on both client and server; half-duplex is fine though
+
+### Justification for only supporting Connect on the server
+
+gRPC is a poor match to Python's most commonly used asynchronous server framework, ASGI.
+A correct gRPC implementation requires control over very low-level details of the connection state and http/2 transport.
+These details are not exposed by ASGI, so supporting them would prevent connect-python's servers from being ASGI applications.
+
+That's an unacceptable trade-off to make because ASGI interoperability is important for integrating connect servers into larger applications, like those running on Django, Starlette or FastAPI.
+
+### Justification for only supporting Connect on the client
+
+Implementing a correct gRPC client again requires low-level control over the transport stack.
+The connect client would need to accept an extremely low-level and generic transport, even when contacting connect servers, just to support gRPC.
+
+This is more acceptable than the server case, but still unpleasant.
+Users will expect that they can pass an httpx.Client or similar to configure instrumentation, authentication, and so on.
+If we use a low-level library like hyper-h2 to implement the client, we'd likely need to build a bespoke abstraction supporting features like authentication which would be quite a bit more scope to cover.
+
+### Justification for only supporting half-duplex streams
+
+This is related to the above two justifications: http/2 is poorly supported in Python today.
+
+## Goals
+
+Fully pass conformance tests, with the following configuration:
+```
+features:
+  versions:
+    - HTTP_VERSION_1
+  protocols:
+    - PROTOCOL_CONNECT
+  codecs:
+    - CODEC_PROTO
+    - CODEC_JSON
+  compressions:
+    - COMPRESSION_IDENTITY
+    - COMPRESSION_GZIP
+    - COMPRESSION_BR
+    - COMPRESSION_ZSTD
+  stream_types:
+    - STREAM_TYPE_UNARY
+    - STREAM_TYPE_CLIENT_STREAM
+    - STREAM_TYPE_SERVER_STREAM
+    - STREAM_TYPE_HALF_DUPLEX_BIDI_STREAM
+  supports_half_duplex_bidi_over_http1: true
+  supports_h2c: false
+```
+
+## General design
+
+Most of the code for both servers and clients will be in a connect-python runtime library, installable with `pip install connect-python`.
+
+A code generator, written in Python and installable with `pip install connect-python[compiler]`, will be available to generate a few functions:
+
+1. Synchronous and asynchronous client constructors
+2. Synchronous and asynchronous `typing.Protocol` that defines the method set that server implementations must follow
+3. Synchronous server constructor that produces a WSGI application given an implementation
+4. Asynchronous server constructor that produces an ASGI application given an implementation
+
+### Full type hinting, checked by mypy
+
+We will make sure the runtime, and all generated code, pass mypy type checks in strict mode.
+
+### Opt-in compression
+
+Compression codecs that are not in the Python standard library (Brotli and zstd) should be supported if their associated libraries are present, but those libraries should not be direct dependencies.
+
+### High- and low-level client APIs
+
+Connect clients are able to send arbitrary headers, and inspect headers sent by servers.
+In certain circumstances, they can also inspect or send trailers.
+Full support of this is enforced by the conformance test suite.
+
+But these advanced features can cloud the API for typical usage.
+Headers and trailers are uinused in the majority of RPC usage; the RPC's message types typically encode all the relevant information.
+
+So, we will provide clients with both high-level simple methods which operate directly on the request and response types, and also low-level methods that wrap request and response types in classes that permit handling of headers and trailers.
+
+The low-level RPCs will be named `call_<rpc>`. For example, `call_converse` or `call_say` for an `rpc Converse` or `rpc Say`.
+The high-level RPCs will be simply named `<rpc>`. For example, `converse` or `say`.
+
+To make this more concrete, here is a portion of the proposed method set of the synchronous Eliza client:
+```python
+class ElizaServiceClient:
+	def say(self, req: SayRequest) -> SayResponse:
+		...
+	
+	def call_say(self, req: SayRequest, extra_headers: MultiDict[str, str], timeout_seconds: float) -> UnaryOutput[SayResponse]:
+		...
+		
+	def converse(self, reqs: Iterable[ConverseRequest]) -> Iterator[ConverseResponse]:
+		...
+		
+	def call_converse(self, reqs: Iterable[ConverseRequest], extra_headers: MultiDict[str, str], timeout_seconds: float) -> StreamOutput[ConverseResponse]:
+		...
+```
+
+The `UnaryOutput` and `StreamOutput` generic wrapper types provide access to response headers, trailers, and Connect protocol errors, as well as the wrapped message.
+
+Analagous methods would be available on the asynchronous client.

--- a/docs/governance/rfc/005-python-implementation.md
+++ b/docs/governance/rfc/005-python-implementation.md
@@ -1,6 +1,6 @@
 # 005: Python Implementation
 
-I propose an official Python implementation of Connect, based on the prototype at https://github.com/firetiger-oss/connect-python/.
+The RFC proposes an official Python implementation of Connect.
 This should include both the client and server side.
 
 ## Why


### PR DESCRIPTION
I'd like to get a Python implementation officially accepted so we can focus our efforts on it.

This is a successor to #71 which I think is abandoned.

I have a prototype at https://github.com/firetiger-oss/connect-python/ which I'd like to see moved into the connectrpc organization. The current state of it is that it has synchronous and asynchronous clients, and a synchronous server (on WSGI).

It supports unary and streaming requests. It passes conformance tests, so it correctly handles the low-level details, including header and trailer metadata, with the configs here:
 - sync client: https://github.com/firetiger-oss/connect-python/blob/main/tests/conformance/sync_config.yaml
 - async client: https://github.com/firetiger-oss/connect-python/blob/main/tests/conformance/async_config.yaml
 - sync server: https://github.com/firetiger-oss/connect-python/blob/main/tests/conformance/sync_server_config.yaml

Unsupported things that I want to support, but haven't gotten around to yet:
- Idempotent GETs
- Compression in the client
- Async server, probably built on Starlette
- httpx client transport for the async client, instead of just aiohttp

I'm open to working on those before blessing this library, or after, whatever works. I expect compression to be simple. GETs may be a little complicated since they involve a totally different encoding scheme to cram things into the URL. The async server is a very significant amount of work; I have a branch at [this PR](https://github.com/firetiger-oss/connect-python/pull/9), but I think I will abandon it as excessively complex, since it tries to work with ASGI directly.