### PR TITLE
fix: chevrons and CNCF logo in dark mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,6 +136,7 @@ const config = {
       colorMode: {
         // We can re-enable later if/when we have design assets
         disableSwitch: false,
+        respectPrefersColorScheme: true,
       },
       algolia: {
         appId: process.env.ALGOLIA_APP_ID || "none",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -141,7 +141,7 @@ html[data-theme="dark"] {
     0px 2px 4px rgba(0, 0, 0, 0.3), 0px 8px 20px rgba(0, 0, 0, 0.2);
 
   /* Menu icon for dark mode */
-  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><g transform="matrix(0.88,0,0,0.88,1.3,1.3)"><path d="M11.505,8.838L11.071,9.271L8,6.2L4.929,9.271L4.496,8.837L8,5.333L11.505,8.838Z" style="fill:rgb(227,227,227);"/></g></svg>');
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><g transform="matrix(0.88,0,0,0.88,1.3,1.3)"><path d="M11.505,8.838L11.071,9.271L8,6.2L4.929,9.271L4.496,8.837L8,5.333L11.505,8.838Z" style="fill:rgb(0,0,0);"/></g></svg>');
 }
 
 .docusaurus-highlight-code-line {
@@ -296,16 +296,6 @@ html[data-theme="dark"] .dropdown__menu > li + li:before {
   .menu__list-item:not(.menu__list-item--collapsed)
   > .menu__link.menu__link--sublist,
 .navbar-sidebar .menu__list-item > .menu__list {
-  background-color: var(--buf-ink-blue-00);
-  border-bottom: 1px solid var(--buf-grey-01);
-}
-
-html[data-theme="dark"]
-  .navbar-sidebar
-  .menu__list-item:not(.menu__list-item--collapsed)
-  > .menu__link.menu__link--sublist,
-html[data-theme="dark"] .navbar-sidebar .menu__list-item > .menu__list {
-  background-color: var(--buf-ink-blue-00);
   border-bottom: 1px solid var(--buf-grey-01);
 }
 

--- a/src/theme/Footer/styles.module.css
+++ b/src/theme/Footer/styles.module.css
@@ -28,6 +28,17 @@
   padding-top: 0.3rem;
 }
 
+/* Fix CNCF logo visibility in dark mode */
+:global(html[data-theme="dark"]) .cncfLogo {
+  fill: white;
+  stroke: white;
+}
+
+:global(html[data-theme="light"]) .cncfLogo {
+  fill: black;
+  stroke: black;
+}
+
 .legalGroup {
   display: flex;
   flex-direction: row;

--- a/src/theme/Navbar/MobileSidebar/Header/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/Header/index.tsx
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from "react";
-import NavbarColorModeToggle from "@theme/Navbar/ColorModeToggle";
 import IconClose from "@theme/Icon/Close";
 import { useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
 import styles from "./styles.module.css";
@@ -40,7 +39,6 @@ export default function NavbarMobileSidebarHeader() {
       }}
     >
       <div className={styles.menuTitle}>Menu</div>
-      <NavbarColorModeToggle className="margin-right--md" />
       <CloseButton />
     </div>
   );


### PR DESCRIPTION
resolve issue mentioned in #299 

1. chevrons for the dropdown
2. CNCF logo in the bottom right corner is still dark
3. os preference
4. (extra) In mobile view, remove dark mode btn from navbar as it is already present on left side of search bar.