### PR TITLE
Make tab-size in codeblocks 2 spaces

### DIFF
--- a/docs/go/interceptors.md
+++ b/docs/go/interceptors.md
@@ -81,14 +81,10 @@ To apply our new interceptor to handlers or clients, we can use
 
 ```go
 // For handlers:
-interceptors := connect.WithInterceptors(
-	NewAuthInterceptor(),
-	validate.NewInterceptor(),
-)
 mux := http.NewServeMux()
 mux.Handle(greetv1connect.NewGreetServiceHandler(
 	&GreetServer{},
-	interceptors,
+	connect.WithInterceptors(NewAuthInterceptor()),
 ))
 ```
 

--- a/docs/go/interceptors.md
+++ b/docs/go/interceptors.md
@@ -81,10 +81,14 @@ To apply our new interceptor to handlers or clients, we can use
 
 ```go
 // For handlers:
+interceptors := connect.WithInterceptors(
+	NewAuthInterceptor(),
+	validate.NewInterceptor(),
+)
 mux := http.NewServeMux()
 mux.Handle(greetv1connect.NewGreetServiceHandler(
 	&GreetServer{},
-	connect.WithInterceptors(NewAuthInterceptor()),
+	interceptors,
 ))
 ```
 

--- a/docs/go/observability.md
+++ b/docs/go/observability.md
@@ -3,7 +3,7 @@ title: Observability
 sidebar_position: 65
 ---
 
-Connect stays close to `net/http`, which means any logging, tracing, or metrics that work with an `http.Handler` or `http.Client` will also work with Connect. In particular, the [otelhttp](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) OpenTelemetry package and the [ochttp](https://pkg.go.dev/go.opencensus.io/plugin/ochttp) OpenCensus package both integrate seamlessly with Connect servers and clients.
+Connect stays close to `net/http`, which means any logging, tracing, or metrics that work with an `http.Handler` or `http.Client` will also work with Connect. In particular, the [otelhttp](https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp) OpenTelemetry package integrates seamlessly with Connect servers and clients.
 
 For more detailed, RPC-focused metrics, use the [otelconnect] package. [otelconnect] works with your [OpenTelemetry] metrics and tracing setup to capture information such as:
 
@@ -67,11 +67,15 @@ When running multiple applications in a single binary, or if different sections 
 
 ```go
 // newInterceptor instruments Connect clients and handlers using custom OpenTelemetry metrics, tracing, and propagation.
-func newInterceptor(tp trace.TracerProvider, mp metric.MeterProvider, p propagation.TextMapPropagator) (connect.Interceptor, error) {
+func newInterceptor(
+	tracerProvider trace.TracerProvider,
+	metricProvider metric.MeterProvider,
+	textMapPropagator propagation.TextMapPropagator
+) (connect.Interceptor, error) {
 	return otelconnect.NewInterceptor(
-		otelconnect.WithTracerProvider(tp),
-		otelconnect.WithMeterProvider(mp),
-		otelconnect.WithPropagator(p),
+		otelconnect.WithTracerProvider(tracerProvider),
+		otelconnect.WithMeterProvider(metricProvider),
+		otelconnect.WithPropagator(textMapPropagator),
 	)
 }
 ```

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -446,6 +446,10 @@ code {
   vertical-align: baseline;
 }
 
+pre {
+  tab-size: 2;
+}
+
 @media (min-width: 997px) {
   .mobile-only {
     display: none;


### PR DESCRIPTION
To limit the horizontal width in the Go examples. Also, tweaked some Go examples in https://github.com/connectrpc/connectrpc.com/commit/f0288d9d652a1989cfb2b7bd4af669e86d833288.