### PR TITLE
Cleanups

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -185,7 +185,6 @@ export default defineConfig({
           label: "Connect for Web",
           collapsed: true,
           items: [
-            { label: "Migrating to v2", slug: "docs/web/migrating-to-v2" },
             { label: "Getting started", slug: "docs/web/getting-started" },
             { label: "Generating code", slug: "docs/web/generating-code" },
             { label: "Using clients", slug: "docs/web/using-clients" },
@@ -214,6 +213,7 @@ export default defineConfig({
             },
             { label: "Server-Side Rendering (SSR)", slug: "docs/web/ssr" },
             { label: "Connect for TanStack Query", slug: "docs/web/query" },
+            { label: "Migrating to v2", slug: "docs/web/migrating-to-v2" },
           ],
         },
         {

--- a/src/components/home/text.ts
+++ b/src/components/home/text.ts
@@ -49,7 +49,7 @@ export const featureList: FeatureItem[] = [
   {
     title: "No boilerplate",
     descriptionHtml:
-      'Define your APIs using <a href="https://developers.google.com/protocol-buffers">Protocol Buffers</a>, the industry’s most battle-tested schema definition language, and skip the hand-written boilerplate. Connect handles server-side routing, serialization, and compression, and it generates idiomatic clients in Go, TypeScript, Swift, and Kotlin.',
+      'Define your APIs using <a href="https://developers.google.com/protocol-buffers">Protocol Buffers</a>, the industry’s most battle-tested schema definition language, and skip the hand-written boilerplate. Connect handles server-side routing, serialization, and compression, and it generates idiomatic clients in Go, TypeScript, Swift, Kotlin, Dart, and Python.',
   },
 ];
 

--- a/src/content/docs/docs/faq.md
+++ b/src/content/docs/docs/faq.md
@@ -7,8 +7,8 @@ description: "Answers to common questions about Connect: project naming, OpenAPI
 
 ### How should I refer to Connect in a blog post or social media?
 
-**Connect** is the name of the project. If that's ambiguous in your context or
-search ranking/uniqueness is important, please use **Connect RPC**.
+Connect is the original name of the project, however we have moved to referencing the
+project as **ConnectRPC**. Connect was simply too ambiguous for SEO.
 
 ### How do I get the OpenAPI spec for the Connect APIs?
 


### PR DESCRIPTION
- Add languages to the features list
- Move the "Migrate to v2" section to the bottom for Web
- Update the FAQ to say to use ConnectRPC as the named reference. We should update all the docs to use ConnectRPC as well.
