### PR TITLE
Update references to protobuf-es manual

### DIFF
--- a/src/content/docs/docs/faq.md
+++ b/src/content/docs/docs/faq.md
@@ -362,7 +362,7 @@ compatible with existing gRPC-web backends. See [Choosing a protocol](/docs/web/
 Connect uses the Protobuf runtime provided by [Protobuf-ES](https://github.com/bufbuild/protobuf-es).
 Additionally, the code generator plugin used by Connect-ES is based on the plugin
 framework also provided by Protobuf-ES. For any questions you may have about this library,
-visit the [Protobuf-ES manual](https://github.com/bufbuild/protobuf-es/blob/main/MANUAL.md).
+visit the [Protobuf-ES documentation](https://protobufes.com/).
 
 #### How do I add types to the descriptor registry for JavaScript?
 

--- a/src/content/docs/docs/node/server-plugins.md
+++ b/src/content/docs/docs/node/server-plugins.md
@@ -211,11 +211,11 @@ All adapters take a set of common options:
 - `interceptors?: Interceptor[]`
   An array of interceptors to apply to all requests. See [Interceptors](/docs/node/interceptors/) for more information.
 - `jsonOptions`
-  Protobuf [JSON serialization options](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#json-serialization-options).
+  Protobuf [JSON serialization options](https://protobufes.com/guides/serialization/#json-serialization-options).
   If your service uses `google.protobuf.Any`, provide a `typeRegistry` with the
   allowed message types.
 - `binaryOptions`
-  Protobuf [binary serialization options](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#binary-serialization-options).
+  Protobuf [binary serialization options](https://protobufes.com/guides/serialization/#binary-serialization-options).
 
 ## HTTP/2, TLS, and gRPC
 

--- a/src/content/docs/docs/web/choosing-a-protocol.mdx
+++ b/src/content/docs/docs/web/choosing-a-protocol.mdx
@@ -97,7 +97,7 @@ our documentation on [SSR](/docs/web/ssr/) to learn more.
 
 ## JSON options
 
-With `jsonOptions`, you can pass any of the [JSON serialization options from Protobuf-ES](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#json-serialization-options):
+With `jsonOptions`, you can pass any of the [JSON serialization options from Protobuf-ES](https://protobufes.com/guides/serialization/#json-serialization-options):
 
 ```ts
 import { createRegistry } from "@bufbuild/protobuf";

--- a/src/content/docs/docs/web/errors.mdx
+++ b/src/content/docs/docs/web/errors.mdx
@@ -118,5 +118,5 @@ generate this message - but any Protobuf message can be transmitted as error
 details.
 
 Alternatively, `findDetails()` takes a registry as an argument. See the
-[Protobuf-ES documentation](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#registries)
+[Protobuf-ES documentation](https://protobufes.com/reference/reflection/registries/)
 for details.

--- a/src/content/docs/docs/web/generating-code.mdx
+++ b/src/content/docs/docs/web/generating-code.mdx
@@ -115,8 +115,7 @@ export const ElizaService: GenService<{
 The full file includes comments, additional RPCs, and exports for several messages, but the `const`
 above really is all Connect needs to provide [clients](/docs/web/using-clients).
 
-To learn more about what `protoc-gen-es` generates, head over to the documentation for the
-[Protobuf-ES project](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#generated-code).
+To learn more about what `protoc-gen-es` generates, head over to the [Protobuf-ES documentation](http://protobufes.com/reference/generated-code/).
 
 ### Using the local files
 

--- a/src/content/docs/docs/web/ssr.mdx
+++ b/src/content/docs/docs/web/ssr.mdx
@@ -21,9 +21,9 @@ Array, Number, String, and Boolean.
 
 **Protobuf message are JSON-serializable out of the box if they:**
 
-- Use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#field-presence-and-default-values)) or the Editions equivalent.
+- Use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://protobufes.com/guides/messages/#field-presence-and-default-values)) or the Editions equivalent.
 - Do not use `bytes` fields.
-- Do not use `int64` or any other 64-bit integer field (unless they have the [option `jstype = JS_STRING`](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#scalar-fields)).
+- Do not use `int64` or any other 64-bit integer field (unless they have the [option `jstype = JS_STRING`](https://protobufes.com/reference/generated-code/field-types/#scalars)).
 - Do not rely on Infinity, or NaN in `double` or `float` fields.
 
 React Server components with Next.js use a more capable serialization logic. In addition to regular JSON-serializable
@@ -31,13 +31,12 @@ types, it also supports BigInt, Infinity, NaN, and Uint8Array.
 
 **Protobuf messages are serializable by React out of the box if they:**
 
-- Use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#field-presence-and-default-values)) or the Editions equivalent.
+- Use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://protobufes.com/guides/messages/#field-presence-and-default-values)) or the Editions equivalent.
 
 If your Protobuf messages are not serializable, there's a simple solution: You convert them to JSON with the
-[toJson function](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#serializing-messages) from
+[toJson function](https://protobufes.com/guides/serialization/#serialize-and-parse) from
 [`@bufbuild/protobuf`](https://www.npmjs.com/package/@bufbuild/protobuf). You can either use the JSON objects (the
-[JSON types](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#json-types) feature will be helpful), or
-parse them again with `fromJson`.
+[JSON types](https://protobufes.com/reference/json-types/) feature will be helpful), or parse them again with `fromJson`.
 
 Let's walk through a few examples in various setups:
 
@@ -202,7 +201,7 @@ Server load functions always run on the server. The data they return is serializ
 sent to the web browser, and hydrated on page load. Svelte 5 uses [devalue](https://github.com/rich-harris/devalue) to
 serialize data, which fully supports BigInt, Infinity, NaN, and Uint8Array.
 
-As long as you use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://github.com/bufbuild/protobuf-es/blob/v2.2.1/MANUAL.md#field-presence-and-default-values)) or the Editions equivalent, you can
+As long as you use the "proto3" syntax (which does not require the [prototype chain to track field presence](https://protobufes.com/guides/messages/#field-presence-and-default-values)) or the Editions equivalent, you can
 safely return Protobuf messages from a server load function.
 
 ### Universal load


### PR DESCRIPTION
We now have a dedicated website for protobuf-es docs.
