### PR TITLE
Remove CocoaPods references from Swift docs

### DIFF
--- a/src/content/docs/docs/swift/getting-started.mdx
+++ b/src/content/docs/docs/swift/getting-started.mdx
@@ -163,25 +163,6 @@ not necessary when using the Connect or gRPC-Web protocol.**
 
 :::
 
-### Alternative: Use CocoaPods
-
-CocoaPods is also supported as an alternative to Swift Package Manager.
-To use Connect-Swift with CocoaPods, simply add this line to your `Podfile`:
-
-```ruby
-pod 'Connect-Swift'
-pod 'SwiftProtobuf'
-```
-
-:::note
-
-Although Connect-Swift provides support for both the Connect and
-the gRPC-Web protocols through CocoaPods, gRPC support is only available when
-using Swift Package Manager due to the fact that
-[SwiftNIO does not support CocoaPods](https://github.com/apple/swift-nio/issues/2393).
-
-:::
-
 ## Integrate into the app
 
 First, add the generated `.swift` files from the previous steps to your
@@ -454,7 +435,6 @@ the Connect-Swift repository on GitHub. These examples demonstrate:
 
 - Using streaming APIs
 - Integrating with Swift Package Manager
-- Integrating with CocoaPods
 - Using the [Connect protocol](/docs/protocol/)
 - Using the [gRPC protocol][grpc]
 - Using the [gRPC-Web protocol][grpc-web]

--- a/src/content/docs/docs/swift/testing.md
+++ b/src/content/docs/docs/swift/testing.md
@@ -211,12 +211,10 @@ To use the [generated mocks](#generating-mocks), you will need to include the
 `ConnectMocks` library which is available in the
 [Connect-Swift repo][connect-swift] alongside the `Connect` library.
 
-It can be integrated via either:
-
-- Swift Package Manager, using the same [GitHub URL][connect-swift]
-  and [instructions](./getting-started#add-the-connect-swift-package) as the
-  main `Connect` library.
-- CocoaPods, using the `Connect-Swift-Mocks` CocoaPod.
+It can be integrated via Swift Package Manager, using the same
+[GitHub URL][connect-swift] and
+[instructions](./getting-started#add-the-connect-swift-package) as the
+main `Connect` library.
 
 You can then write unit tests that inject the mock implementations instead of
 the production implementations, making validating requests and providing mocked


### PR DESCRIPTION
Removes CocoaPods as a documented installation option for Connect-Swift.

- `swift/getting-started`: drops the "Alternative: Use CocoaPods" section (Podfile snippet and the SwiftNIO/gRPC caveat), plus the CocoaPods bullet under "More examples".
- `swift/testing`: `ConnectMocks` integration is now documented for Swift Package Manager only.

> [!IMPORTANT]
> Blocked by https://github.com/connectrpc/connect-swift/pull/414, which must merge before this.
