### PR TITLE
Add vanity import path for connectrpc.com/connect/v2

### DIFF
--- a/public/connect-v2.html
+++ b/public/connect-v2.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="connectrpc.com/connect/v2 git https://github.com/connectrpc/connect-go"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://pkg.go.dev/connectrpc.com/connect/v2"
+    />
+  </head>
+  <body>
+    API documentation for <code>connectrpc.com/connect/v2</code> is on
+    <a href="https://pkg.go.dev/connectrpc.com/connect/v2">pkg.go.dev</a>.
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,11 @@
       "destination": "/connect.html",
       "permanent": true
     },
+    {
+      "source": "/connect/v2/",
+      "destination": "/connect-v2.html",
+      "permanent": true
+    },
     { "source": "/cors/", "destination": "/cors.html", "permanent": true },
     {
       "source": "/grpchealth/",


### PR DESCRIPTION
This adds a vanity import path for `connectrpc.com/connect/v2` as part of [connect-go v2]( https://github.com/connectrpc/connect-go/pull/951).

The repo root is unchanged. Only the import prefix gains the `/v2` suffix. Subpackages (`connecthttp`, `connectgzip`, `connectinprocess`, `connectproto`, `cmd/...`) don't need a separate page and all resolve under the `/v2/...`.  Ecosystem packages ( `grpchealth`, `grpcreflect`, `otelconnect`, `validate`, `vanguard`) will be done in a following PR. 