### PR TITLE
fix canonical URL metadata tag

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,10 +18,17 @@ import { defineConfig } from "astro/config";
 import { remarkHeadingId } from "remark-custom-heading-id";
 import { remarkLinkChecker } from "./src/plugins/remark-link-checker";
 
+// Canonical site URL. On Vercel, VERCEL_URL is always set — even on
+// production builds — to the unique per-deployment hostname (e.g.
+// connectrpc-com-abc123.vercel.app). Keying off its presence made
+// production pages emit canonical/og/sitemap URLs pointing at the
+// deployment host, which caused Google to treat that vercel.app URL as
+// canonical instead of connectrpc.com. Only fall back to VERCEL_URL for
+// preview deployments so their absolute links still resolve.
 const publicUrl =
-  process.env.VERCEL_URL === undefined
-    ? "https://connectrpc.com"
-    : `https://${process.env.VERCEL_URL}`;
+  process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "https://connectrpc.com";
 
 export default defineConfig({
   site: publicUrl,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://connectrpc.com/sitemap-index.xml

--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,11 @@
           "value": "default-src 'none'; base-uri 'self'; frame-ancestors 'none'; connect-src 'self' https://demo.connectrpc.com cdn.usefathom.com *.google-analytics.com *.googletagmanager.com https://vercel.live *.vercel.app wss:; font-src 'self' data:; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' cdn.usefathom.com *.googletagmanager.com www.gstatic.com https://vercel.live *.vercel.app; style-src 'self' 'unsafe-inline'; manifest-src 'self'; worker-src 'self' blob:"
         }
       ]
+    },
+    {
+      "source": "/(.*)",
+      "has": [{ "type": "host", "value": ".*\\.vercel\\.app" }],
+      "headers": [{ "key": "X-Robots-Tag", "value": "noindex" }]
     }
   ],
   "redirects": [


### PR DESCRIPTION
The live website has canonical URLs that look like this: https://connect-h0szgrtu7-connectrpc.vercel.app/[path]

This is absolutely not correct. These should start with https://connectrpc.com

This fixes the issue in two ways:
- Only use process.env.VERCEL_URL as-is if VERCEL_ENV is a preview. Otherwise, use "https://connectrpc.com"
- Adds `X-Robots-Tag: noindex` header whenever the URL is on the vercel.app domain

This also adds a robots.txt file that references the sitemap.