### PR TITLE
Add vanity import path for connect-go-v2-migrate

### DIFF
--- a/public/connect-v2-migrate.html
+++ b/public/connect-v2-migrate.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <!--
+      Must keep this go-import tag identical to connect-v2.html.
+      Go subtracts the prefix to find the module root, and verifies this tag
+      against connect-v2.html.
+    -->
+    <meta
+      name="go-import"
+      content="connectrpc.com/connect/v2 git https://github.com/connectrpc/connect-go"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://pkg.go.dev/connectrpc.com/connect/v2/cmd/connect-go-v2-migrate"
+    />
+  </head>
+  <body>
+    API documentation for
+    <code>connectrpc.com/connect/v2/cmd/connect-go-v2-migrate</code> is on
+    <a
+      href="https://pkg.go.dev/connectrpc.com/connect/v2/cmd/connect-go-v2-migrate"
+      >pkg.go.dev</a
+    >.
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -46,6 +46,11 @@
       "destination": "/connect-v2.html",
       "permanent": true
     },
+    {
+      "source": "/connect/v2/cmd/connect-go-v2-migrate/",
+      "destination": "/connect-v2-migrate.html",
+      "permanent": true
+    },
     { "source": "/cors/", "destination": "/cors.html", "permanent": true },
     {
       "source": "/grpchealth/",


### PR DESCRIPTION
This adds a vanity import path for `connectrpc.com/connect/v2/cmd/connect-go-v2-migrate` as part of [connect-go v2](https://github.com/connectrpc/connect-go/pull/951), where the migration tool becomes its own Go module.

The tool is released under tags of the form `cmd/connect-go-v2-migrate/vX.Y.Z`. Its version line is its own and starts at `v1.0.0`, it is not tied to the library's `v2.x.y` tags.

The go-import meta here deliberately names `connectrpc.com/connect/v2` rather than the full module path. Go subtracts that prefix to find the module's subdirectory, `cmd/connect-go-v2-migrate`, which is also the tag prefix it searches. Because that prefix is shorter than the requested import path, Go then re-fetches `/connect/v2?go-get=1` and requires that page's go-import meta to be identical to this one, so the two HTML files have to stay in sync.