### PR TITLE
Update connect-go interceptor examples

### DIFF
--- a/src/content/docs/docs/go/deployment.md
+++ b/src/content/docs/docs/go/deployment.md
@@ -3,8 +3,8 @@ title: Deployment & h2c
 ---
 
 After building a Connect API, you still need to deploy it to production. This
-guide covers how to configure timeouts, observability, HTTP/2 without TLS and
-CORS.
+guide covers how to configure timeouts, message size limits, observability,
+HTTP/2 without TLS and CORS.
 
 ## Timeouts and connection pools
 
@@ -48,6 +48,34 @@ Also, if your [http.Server](https://pkg.go.dev/net/http#Server) has the
 `ReadTimeout` or `WriteTimeout` field configured, it applies to the entire
 operation duration, even for streaming calls. See the [FAQ](/docs/faq/#stream-error)
 for more information.
+
+## Message size limits
+
+By default, Connect doesn't limit the size of messages. A client can make your
+server buffer an arbitrarily large message in memory. Before exposing a server
+to untrusted clients, always set a limit with
+[`WithReadMaxBytes`][read-max-bytes]:
+
+```go
+mux.Handle(greetv1connect.NewGreetServiceHandler(
+	&GreetServer{},
+	connect.WithReadMaxBytes(4*1024*1024), // 4 MiB per message
+))
+```
+
+The limit applies to each message after decompression. Messages over the limit
+fail with `CodeResourceExhausted`. The same option works on clients, where it
+protects against oversized responses.
+
+Because streaming RPCs exchange many messages, `WithReadMaxBytes` bounds each
+message but not the stream as a whole. To also bound the total number of bytes
+read from the network, wrap your handlers with
+[`http.MaxBytesHandler`][max-bytes-handler]:
+
+```go
+var handler http.Handler = mux
+handler = http.MaxBytesHandler(handler, 32*1024*1024) // 32 MiB per request
+```
 
 ## Observability
 
@@ -114,6 +142,8 @@ func newInsecureClient() *http.Client {
 [cloudflare-timeouts]: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/
 [go-deadlines]: https://github.com/golang/go/issues/16100
 [http-protocols]: https://pkg.go.dev/net/http#Protocols
+[max-bytes-handler]: https://pkg.go.dev/net/http#MaxBytesHandler
+[read-max-bytes]: https://pkg.go.dev/connectrpc.com/connect#WithReadMaxBytes
 
 ## CORS
 

--- a/src/content/docs/docs/go/interceptors.md
+++ b/src/content/docs/docs/go/interceptors.md
@@ -36,39 +36,31 @@ Most unary interceptors are best implemented as a `UnaryInterceptorFunc`.
 
 ## An example
 
-That's a little abstract, so let's consider an example: we'd like to apply a
-simple header-based authentication scheme to our RPCs. We could add this logic
-to each method on our server, but it's less error-prone to write an interceptor
-instead.
+That's a little abstract, so let's consider an example: we'd like to log every
+RPC. We could add logging to each method on our server, but it's less
+error-prone to write an interceptor instead.
 
 ```go
 package example
 
 import (
 	"context"
-	"errors"
+	"log/slog"
 
 	"connectrpc.com/connect"
 )
 
-const tokenHeader = "Acme-Token"
-
-func NewAuthInterceptor() connect.UnaryInterceptorFunc {
+func NewLoggingInterceptor() connect.UnaryInterceptorFunc {
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(
 			ctx context.Context,
 			req connect.AnyRequest,
 		) (connect.AnyResponse, error) {
-			if req.Spec().IsClient {
-				// Send a token with client requests.
-				req.Header().Set(tokenHeader, "sample")
-			} else if req.Header().Get(tokenHeader) == "" {
-				// Check token in handlers.
-				return nil, connect.NewError(
-					connect.CodeUnauthenticated,
-					errors.New("no token provided"),
-				)
-			}
+			spec := req.Spec()
+			slog.InfoContext(ctx, "rpc",
+				"procedure", spec.Procedure,
+				"is_client", spec.IsClient,
+			)
 			return next(ctx, req)
 		}
 	}
@@ -81,7 +73,7 @@ To apply our new interceptor to handlers or clients, we can use
 ```go
 // For handlers:
 interceptors := connect.WithInterceptors(
-	NewAuthInterceptor(),
+	NewLoggingInterceptor(),
 	validate.NewInterceptor(),
 )
 mux := http.NewServeMux()
@@ -96,6 +88,16 @@ mux.Handle(greetv1connect.NewGreetServiceHandler(
 client := greetv1connect.NewGreetServiceClient(
 	http.DefaultClient,
 	"http://localhost:8080",
-	connect.WithInterceptors(NewAuthInterceptor()),
+	connect.WithInterceptors(NewLoggingInterceptor()),
 )
 ```
+
+## Authentication
+
+Don't use interceptors to authenticate requests on the server. Handlers run
+unary interceptors _after_ the request message has been read, decompressed, and
+unmarshaled. An interceptor-based check lets unauthenticated clients consume
+memory and CPU on your server. Instead, authenticate at the HTTP layer with
+standard `net/http` middleware, which runs before Connect reads the request
+body. The [authn-go](https://github.com/connectrpc/authn-go) package provides
+authentication middleware designed for Connect servers.


### PR DESCRIPTION
The interceptors page for connect-go showed authentication built with an interceptor. This pattern is not recommended. Unary interceptors run after the request message has been read, decompressed, and unmarshaled, so unauthenticated clients can consume server resources. [RFC 002](https://github.com/connectrpc/connectrpc.com/blob/main/src/content/docs/docs/governance/rfc/002-go-cors-authn.md) addressed this and added [authn-go](https://github.com/connectrpc/authn-go)  so users can authenticate at the HTTP layer instead.

The interceptor example is now a logging interceptor, and a new Authentication section links to authn-go. The deployment guide now covers message size limits, since Connect defaults to allowing messages of any size.
