### PR TITLE
Update connect-py interceptor examples

### DIFF
--- a/src/content/docs/docs/python/deployment.mdx
+++ b/src/content/docs/docs/python/deployment.mdx
@@ -2,12 +2,14 @@
 title: Deployment
 ---
 
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
 import VersionWarning from './_version-warning.mdx';
 
 <VersionWarning />
 
 After building a Connect service, you still need to deploy it to production. This guide covers how to
-use a Python application server to run a service.
+use a Python application server to run a service, configure message size limits, and enable CORS.
 
 ## Application Servers
 
@@ -41,6 +43,49 @@ very new and needs more time with real-world applications to verify stability.
 
 Keep the above in mind when picking an HTTP/2 server and let us know how it goes if you give any a try.
 When in doubt, if you do not use bidirectional streaming, we recommend one of the HTTP/1.1 servers.
+
+## Message size limits
+
+By default, Connect limits the size of messages to 4MB, so a client can't make your server
+buffer an arbitrarily large message in memory. To change the limit, pass `read_max_bytes`
+to the application constructor:
+
+<Tabs syncKey="python-type">
+  <TabItem label="ASGI">
+
+    ```python
+    app = GreetServiceASGIApplication(
+        Greeter(),
+        read_max_bytes=1024 * 1024 * 16,  # 16MB per message
+    )
+    ```
+
+  </TabItem>
+  <TabItem label="WSGI">
+
+    ```python
+    app = GreetServiceWSGIApplication(
+        Greeter(),
+        read_max_bytes=1024 * 1024 * 16,  # 16MB per message
+    )
+    ```
+
+  </TabItem>
+</Tabs>
+
+The limit applies to each message, both as read from the network and after decompression.
+Messages over the limit fail with `Code.RESOURCE_EXHAUSTED`.
+
+Because streaming RPCs exchange many messages, `read_max_bytes` bounds each message but not
+the stream as a whole. To also bound the total number of bytes read from the network, wrap
+the application with ASGI or WSGI middleware such as Starlette's
+[`RequestBodyLimitMiddleware`](https://www.starlette.io/middleware/#requestbodylimitmiddleware):
+
+```python
+from starlette.middleware.body_limit import RequestBodyLimitMiddleware
+
+app = RequestBodyLimitMiddleware(app, max_body_size=1024 * 1024 * 32)  # 32MB per request
+```
 
 ## CORS
 

--- a/src/content/docs/docs/python/interceptors.mdx
+++ b/src/content/docs/docs/python/interceptors.mdx
@@ -258,6 +258,6 @@ unary interceptors _after_ the request message has been read, decompressed, and
 deserialized. An interceptor-based check lets unauthenticated clients consume
 memory and CPU on your server. Instead, authenticate with standard ASGI or WSGI middleware,
 which runs before Connect reads the request body. Starlette's
-[`AuthenticationMiddleware`](https://www.starlette.io/authentication/) provides
+[`AuthenticationMiddleware`](https://starlette.dev/authentication/) provides
 authentication middleware that works with any ASGI application, including
 Connect servers.

--- a/src/content/docs/docs/python/interceptors.mdx
+++ b/src/content/docs/docs/python/interceptors.mdx
@@ -224,7 +224,7 @@ An interceptor timing each RPC and logging its duration may look like this:
 
         async def on_end[REQ, RES](self, start: float, ctx: RequestContext[REQ, RES], error: Exception | None) -> None:
             duration = time.perf_counter() - start
-            logger.info("%s took %.3fs", ctx.method().name, duration)
+            logger.info("%s took %.3fs", ctx.method.name, duration)
     ```
 
   </TabItem>

--- a/src/content/docs/docs/python/interceptors.mdx
+++ b/src/content/docs/docs/python/interceptors.mdx
@@ -203,109 +203,61 @@ Client constructors also accept an `interceptors=` parameter.
 ## Metadata interceptors
 
 Because the signature is different for each RPC type, we have an interceptor protocol for each
-to be able to intercept RPC messages. However, many interceptors, such as for authentication or
+to be able to intercept RPC messages. However, many interceptors, such as for metrics or
 tracing, only need access to headers and not messages. Connect provides a metadata interceptor
 protocol that can be implemented to work with any RPC type.
 
-An authentication interceptor checking bearer tokens and storing them to a context variable may look like this:
+An interceptor timing each RPC and logging its duration may look like this:
 
 <Tabs syncKey="python-type">
   <TabItem label="ASGI">
 
     ```python
-    from contextvars import ContextVar, Token
+    import logging
+    import time
 
-    _auth_token: ContextVar[str] = ContextVar("current_auth_token")
+    logger = logging.getLogger(__name__)
 
-    class ServerAuthInterceptor:
-        def __init__(self, valid_tokens: list[str]) -> None:
-            self._valid_tokens = valid_tokens
+    class TimingInterceptor:
+        async def on_start[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> float:
+            return time.perf_counter()
 
-        async def on_start[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> Token[str]:
-            authorization = ctx.request_headers().get("authorization")
-            if not authorization or not authorization.startswith("Bearer "):
-                raise ConnectError(Code.UNAUTHENTICATED, "missing or malformed bearer token")
-            token = authorization[len("Bearer "):]
-            if token not in self._valid_tokens:
-                raise ConnectError(Code.PERMISSION_DENIED, "token not recognized")
-            return _auth_token.set(token)
-
-        async def on_end[REQ, RES](self, token: Token[str], ctx: RequestContext[REQ, RES], error: Exception | None) -> None:
-            _auth_token.reset(token)
+        async def on_end[REQ, RES](self, start: float, ctx: RequestContext[REQ, RES], error: Exception | None) -> None:
+            duration = time.perf_counter() - start
+            logger.info("%s took %.3fs", ctx.method().name, duration)
     ```
 
   </TabItem>
   <TabItem label="WSGI">
 
     ```python
-    from contextvars import ContextVar, Token
+    import logging
+    import time
 
-    _auth_token: ContextVar[str] = ContextVar("current_auth_token")
+    logger = logging.getLogger(__name__)
 
-    class ServerAuthInterceptor:
-        def __init__(self, valid_tokens: list[str]) -> None:
-            self._valid_tokens = valid_tokens
+    class TimingInterceptor:
+        def on_start_sync[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> float:
+            return time.perf_counter()
 
-        def on_start_sync[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> Token[str]:
-            authorization = ctx.request_headers().get("authorization")
-            if not authorization or not authorization.startswith("Bearer "):
-                raise ConnectError(Code.UNAUTHENTICATED, "missing or malformed bearer token")
-            token = authorization[len("Bearer "):]
-            if token not in self._valid_tokens:
-                raise ConnectError(Code.PERMISSION_DENIED, "token not recognized")
-            return _auth_token.set(token)
-
-        def on_end_sync[REQ, RES](self, token: Token[str], ctx: RequestContext[REQ, RES], error: Exception | None) -> None:
-            _auth_token.reset(token)
+        def on_end_sync[REQ, RES](self, start: float, ctx: RequestContext[REQ, RES], error: Exception | None) -> None:
+            duration = time.perf_counter() - start
+            logger.info("%s took %.3fs", ctx.method().name, duration)
     ```
 
   </TabItem>
 </Tabs>
 
 `on_start` can return any value, which is passed to the optional `on_end` method. Here, we
-return the token to reset the context variable.
+return the start time to compute the RPC's duration.
 
-Clients can add an interceptor that reads the token from the context variable and populates
-the authorization header.
+## Authentication
 
-<Tabs syncKey="python-type">
-  <TabItem label="Async">
-
-    ```python
-    from contextvars import ContextVar
-
-    from connectrpc.request import RequestContext
-
-    _auth_token: ContextVar[str] = ContextVar("current_auth_token")
-
-    class ClientAuthInterceptor:
-        async def on_start[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> None:
-            auth_token = _auth_token.get(None)
-            if auth_token:
-                ctx.request_headers()["authorization"] = f"Bearer {auth_token}"
-    ```
-
-  </TabItem>
-  <TabItem label="Sync">
-
-    ```python
-    from contextvars import ContextVar
-
-    from connectrpc.request import RequestContext
-
-    _auth_token: ContextVar[str] = ContextVar("current_auth_token")
-
-    class ClientAuthInterceptor:
-        def on_start_sync[REQ, RES](self, ctx: RequestContext[REQ, RES]) -> None:
-            auth_token = _auth_token.get(None)
-            if auth_token:
-                ctx.request_headers()["authorization"] = f"Bearer {auth_token}"
-    ```
-
-  </TabItem>
-</Tabs>
-
-Note that in the client interceptor, we do not need to define `on_end`.
-
-The above interceptors would allow a server to receive and validate an auth token and automatically
-propagate it to the authorization header of backend calls.
+Don't use interceptors to authenticate requests on the server. Handlers run
+unary interceptors _after_ the request message has been read, decompressed, and
+deserialized. An interceptor-based check lets unauthenticated clients consume
+memory and CPU on your server. Instead, authenticate with standard ASGI or WSGI middleware,
+which runs before Connect reads the request body. Starlette's
+[`AuthenticationMiddleware`](https://www.starlette.io/authentication/) provides
+authentication middleware that works with any ASGI application, including
+Connect servers.


### PR DESCRIPTION
Same as #404 for Python

I ended up dropping the client interceptor example that was also auth, but I think it's acceptable

Will merge after releasing https://github.com/connectrpc/connect-py/pull/325