### PR TITLE
Clean up Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
           - "react"
           - "react-dom"
           - "@types/react"
+          - "@types/react-dom"
           - "@react-hookz/web"
       demo:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,9 @@ updates:
           - "@astrojs/*"
       format:
         patterns:
+          - "@biomejs/biome"
           - "@bufbuild/license-header"
-          - "prettier"
-          - "esbuild"
+          - "rumdl"
       react:
         patterns:
           - "react"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,9 @@ updates:
           - "@biomejs/biome"
           - "@bufbuild/license-header"
           - "rumdl"
+      fonts:
+        patterns:
+          - "@fontsource/*"
       react:
         patterns:
           - "react"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       day: "monday"
       timezone: UTC
       time: "07:00"
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
Originally fixing `@types/react-dom` to be in the `react` group, but then figured we could go further here: group GitHub Actions updates, create a `fonts` group, and fix the `format` group.